### PR TITLE
Check negative amount in `GetUnbondingAmount` func

### DIFF
--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -98,7 +98,10 @@ func (k *Keeper) GetDelegatedAmount(ctx sdk.Context, zone *types.Zone) sdk.Coin 
 func (k *Keeper) GetUnbondingAmount(ctx sdk.Context, zone *types.Zone) sdk.Coin {
 	out := sdk.NewCoin(zone.BaseDenom, sdk.ZeroInt())
 	k.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, types.WithdrawStatusUnbond, func(index int64, wr types.WithdrawalRecord) (stop bool) {
-		out = out.Add(wr.Amount[0])
+		amount := wr.Amount[0]
+		if !amount.IsNegative() {
+			out = out.Add(amount)
+		}
 		return false
 	})
 	return out


### PR DESCRIPTION
## 1. Summary
Fixes #610 
<!-- What are you changing, removing, or adding in this review? -->

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details
- Add checking `negative` case of `amount` `WithdrawalRecord` in `GetUnbondingAmount`

