### PR TITLE
x/participationrewards/keeper: move cheap prefix checks to front + better error UX

### DIFF
--- a/x/participationrewards/keeper/callbacks.go
+++ b/x/participationrewards/keeper/callbacks.go
@@ -204,13 +204,13 @@ func UmeeReservesUpdateCallback(ctx sdk.Context, k *Keeper, response []byte, que
 }
 
 func UmeeTotalBorrowsUpdateCallback(ctx sdk.Context, k *Keeper, response []byte, query icqtypes.Query) error {
+	if g, w := query.Request[0], umeetypes.KeyPrefixAdjustedTotalBorrow[0]; g != w {
+		return fmt.Errorf("unexpected query request prefix %q, want %q", g, w)
+	}
+
 	totalBorrows := sdk.ZeroDec()
 	if err := totalBorrows.Unmarshal(response); err != nil {
 		return err
-	}
-
-	if query.Request[0] != umeetypes.KeyPrefixAdjustedTotalBorrow[0] {
-		return errors.New("query request has unexpected prefix")
 	}
 
 	denom := umeetypes.DenomFromKey(query.Request, umeetypes.KeyPrefixAdjustedTotalBorrow)
@@ -241,13 +241,13 @@ func UmeeTotalBorrowsUpdateCallback(ctx sdk.Context, k *Keeper, response []byte,
 }
 
 func UmeeInterestScalarUpdateCallback(ctx sdk.Context, k *Keeper, response []byte, query icqtypes.Query) error {
+	if g, w := query.Request[0], umeetypes.KeyPrefixInterestScalar[0]; g != w {
+		return fmt.Errorf("unexpected query request prefix %q, want %q", g, w)
+	}
+
 	interestScalar := sdk.ZeroDec()
 	if err := interestScalar.Unmarshal(response); err != nil {
 		return err
-	}
-
-	if query.Request[0] != umeetypes.KeyPrefixInterestScalar[0] {
-		return errors.New("query request has unexpected prefix")
 	}
 
 	denom := umeetypes.DenomFromKey(query.Request, umeetypes.KeyPrefixInterestScalar)


### PR DESCRIPTION
This change moves the cheaper prefix checks per request to the top of each of UmeeTotalBorrowsUpdateCallback and UmeeInterestScalarUpdateCallback, prefix checks as it is unnecessary to invoke an expensive unmarshalling yet the result will be discarded from the result of a simple equals check. While here, also improved the error user experience (UX) for prefix mismatches to return the prefix that was retrieved vs expected.

Fixes #776