### PR TITLE
fix: remove unused function with limited behaviour

### DIFF
--- a/utils/strings.go
+++ b/utils/strings.go
@@ -1,12 +1,5 @@
 package utils
 
-// LengthPrefixString returns length-prefixed bytes representation of a string.
-func LengthPrefixString(s string) []byte {
-	bz := []byte(s)
-	bzLen := len(bz)
-	return append([]byte{byte(bzLen)}, bz...)
-}
-
 // create a map from a slice of strings for efficient lookup
 func StringSliceToMap(in []string) map[string]bool {
 	out := make(map[string]bool, len(in))


### PR DESCRIPTION
## 1. Summary
Fixes #866 

Remove unused function `LengthPrefixString ` that was liable to overflow with strings > 255 chars.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
