### PR TITLE
refactor so we do error checking before creating protocol data

### DIFF
--- a/x/participationrewards/keeper/proposal_handler.go
+++ b/x/participationrewards/keeper/proposal_handler.go
@@ -8,8 +8,6 @@ import (
 
 // HandleAddProtocolDataProposal is a handler for executing a passed add protocol data proposal.
 func HandleAddProtocolDataProposal(ctx sdk.Context, k *Keeper, p *types.AddProtocolDataProposal) error {
-	protocolData := types.NewProtocolData(p.Type, p.Data)
-
 	if err := p.ValidateBasic(); err != nil {
 		return err
 	}
@@ -27,6 +25,8 @@ func HandleAddProtocolDataProposal(ctx sdk.Context, k *Keeper, p *types.AddProto
 	if err := pd.ValidateBasic(); err != nil {
 		return err
 	}
+
+	protocolData := types.NewProtocolData(p.Type, p.Data)
 
 	k.SetProtocolData(ctx, pd.GenerateKey(), protocolData)
 


### PR DESCRIPTION
## 1. Summary
Fixes #838

Refactor so we don't create PD before error checking.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
