### PR TITLE
specify codeql packs by language

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,7 @@
+packs:
+  go:
+    - +crypto-com/cosmos-sdk-codeql
+
+
+
+

--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,6 +1,6 @@
 packs:
   go:
-    - +crypto-com/cosmos-sdk-codeql
+    - crypto-com/cosmos-sdk-codeql
 
 
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "**.go"
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           languages: "go, javascript, typescript"
           queries: +security-and-quality,github/codeql/go/ql/src/experimental/InconsistentCode/DeferInLoop.ql@main,github/codeql/go/ql/src/experimental/Unsafe/WrongUsageOfUnsafe.ql@main,github/codeql/go/ql/src/experimental/CWE-369/DivideByZero.ql@main
-          packs: +crypto-com/cosmos-sdk-codeql
+          config-file: ./.github/codeql/codeql-config.yml
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,6 @@ name: "CodeQL"
 
 on:
   pull_request:
-    paths:
-      - "**.go"
     branches:
       - main
   push:
@@ -11,8 +9,8 @@ on:
       - main
       - develop
       - release/**
-    paths:
-      - "**.go"
+
+
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           languages: "go, javascript, typescript"
           queries: +security-and-quality,github/codeql/go/ql/src/experimental/InconsistentCode/DeferInLoop.ql@main,github/codeql/go/ql/src/experimental/Unsafe/WrongUsageOfUnsafe.ql@main,github/codeql/go/ql/src/experimental/CWE-369/DivideByZero.ql@main
-          config-file: ./.github/codeql/codeql-config.yml
+          config-file: ./.github/codeql/config.yml
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
## 1. Summary

Codeql is failing because we aren't specifying packs by language

## 2.Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## 3. Implementation details

Add a codeql configuration file

## 4. How to test/use

If codeql works then we are all set

