### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 20
     ignore:
-      - github.com/cosmos/cosmos-sdk
+      - "github.com/cosmos/cosmos-sdk"
     labels:
       - automerge
       - dependencies


### PR DESCRIPTION
## 1. Summary
Ignoring stuff with dependabot requires that you give it a string. 
