### PR TITLE
correctly configure the ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,8 @@ updates:
       interval: daily
     open-pull-requests-limit: 20
     ignore:
-      - "github.com/cosmos/cosmos-sdk"
+      dependency-name:
+        - "github.com/cosmos/cosmos-sdk"
     labels:
       - automerge
       - dependencies


### PR DESCRIPTION
## 1. Summary
Dependabot should now be able to fix things, without randomly upgrading us to sdk 50. 