### PR TITLE
fix: allow chainId without hyphen. Fixes #974

### DIFF
--- a/x/interchainquery/types/msgs.go
+++ b/x/interchainquery/types/msgs.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"errors"
-	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -31,10 +30,8 @@ func (msg MsgSubmitQueryResponse) ValidateBasic() error {
 		return errors.New("height must be non-negative")
 	}
 
-	// TODO: is there a chain validation spec in ICS?
-	chainParts := strings.Split(msg.ChainId, "-")
-	if len(chainParts) < 2 && msg.ChainId != "provider" {
-		return errors.New("chainID must be of form XXXX-N")
+	if len(msg.ChainId) < 2 {
+		return errors.New("invalid chain id")
 	}
 
 	if len(msg.QueryId) != 64 {

--- a/x/participationrewards/types/protocol_data_test.go
+++ b/x/participationrewards/types/protocol_data_test.go
@@ -81,26 +81,6 @@ func TestLiquidProtocolData_ValidateBasic(t *testing.T) {
 			},
 			false,
 		},
-		{
-			"liquid_invalid_chainid",
-			types.LiquidAllowedDenomProtocolData{
-				ChainID:               "badzone",
-				IbcDenom:              "ibc/3020922B7576FC75BBE057A0290A9AEEFF489BB1113E6E365CE472D4BFB7FFA3",
-				QAssetDenom:           "uqstake",
-				RegisteredZoneChainID: "testzone-1",
-			},
-			true,
-		},
-		{
-			"liquid_invalid_rzchainid",
-			types.LiquidAllowedDenomProtocolData{
-				ChainID:               "somechain-1",
-				IbcDenom:              "ibc/3020922B7576FC75BBE057A0290A9AEEFF489BB1113E6E365CE472D4BFB7FFA3",
-				QAssetDenom:           "uqstake",
-				RegisteredZoneChainID: "badzone",
-			},
-			true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/participationrewards/types/submodule_liquid.go
+++ b/x/participationrewards/types/submodule_liquid.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"strings"
-
 	"github.com/ingenuity-build/multierror"
 )
 
@@ -26,16 +24,8 @@ func (lpd *LiquidAllowedDenomProtocolData) ValidateBasic() error {
 		errs["ChainID"] = ErrUndefinedAttribute
 	}
 
-	if len(strings.Split(lpd.ChainID, "-")) < 2 {
-		errs["ChainID"] = ErrInvalidChainID
-	}
-
 	if lpd.RegisteredZoneChainID == "" {
 		errs["RegisteredZoneChainID"] = ErrUndefinedAttribute
-	}
-
-	if len(strings.Split(lpd.RegisteredZoneChainID, "-")) < 2 {
-		errs["RegisteredZoneChainID"] = ErrInvalidChainID
 	}
 
 	if lpd.QAssetDenom == "" {

--- a/x/participationrewards/types/submodule_osmosis.go
+++ b/x/participationrewards/types/submodule_osmosis.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/ingenuity-build/multierror"
@@ -95,7 +94,7 @@ func (opd *OsmosisPoolProtocolData) ValidateBasic() error {
 	for _, ibcdenom := range utils.Keys(opd.Denoms) {
 		el := fmt.Sprintf("Denoms[%s]", ibcdenom)
 
-		if opd.Denoms[ibcdenom].ChainID == "" || len(strings.Split(opd.Denoms[ibcdenom].ChainID, "-")) < 2 {
+		if opd.Denoms[ibcdenom].ChainID == "" {
 			errs[el+" key"] = fmt.Errorf("%w, chainID", ErrInvalidChainID)
 		}
 


### PR DESCRIPTION
## 1. Summary
Fixes #974 

Remove the requirement for a chainId to contain a hyphen.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

Remove ValidateBasic checks that reject chainids without hyphens, to support `provider` and `celestia`.
