### PR TITLE
fix: permit zero rewards in validatorselectionrewardscallback

### DIFF
--- a/x/participationrewards/keeper/rewards_validatorSelection.go
+++ b/x/participationrewards/keeper/rewards_validatorSelection.go
@@ -162,17 +162,13 @@ func (k Keeper) CalcOverallScores(
 
 	rewards := delegatorRewards.GetRewards()
 	if rewards == nil {
-		err := errors.New("no delegator rewards")
-		k.Logger(ctx).Error(err.Error())
-		return err
+		return nil
 	}
 
 	total := delegatorRewards.GetTotal().AmountOf(zone.BaseDenom)
 
 	if total.IsZero() {
-		err := errors.New("no delegator rewards (2)")
-		k.Logger(ctx).Error(err.Error())
-		return err
+		return nil
 	}
 
 	expected := total.Quo(sdk.NewDec(int64(len(rewards))))

--- a/x/participationrewards/keeper/rewards_validatorSelection_test.go
+++ b/x/participationrewards/keeper/rewards_validatorSelection_test.go
@@ -438,7 +438,7 @@ func (suite *KeeperTestSuite) TestCalcOverallScores() {
 			},
 			verify: func(_ types.ZoneScore, _ []distributiontypes.DelegationDelegatorReward, _ []icstypes.Validator) {
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "zero total rewards",
@@ -454,7 +454,7 @@ func (suite *KeeperTestSuite) TestCalcOverallScores() {
 			},
 			verify: func(_ types.ZoneScore, _ []distributiontypes.DelegationDelegatorReward, _ []icstypes.Validator) {
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "validator removed from active set - performance greater than limit",


### PR DESCRIPTION
## 1. Summary
Fixes #977 

Tolerate payload containing zero accrued rewards by the performance account in the previous epoch.

Short circuit and return nil.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Nil rewards are entirely valid (although uncommon), and we should accept this as a valid value.

