### PR TITLE
tools: add upgrade handler for v1.4.5-rc4

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -44,6 +44,7 @@ const (
 	V010405rc0UpgradeName    = "v1.4.5-rc0"
 	V010405rc2UpgradeName    = "v1.4.5-rc2"
 	V010405rc3UpgradeName    = "v1.4.5-rc3"
+	V010405rc4UpgradeName    = "v1.4.5-rc4"
 
 	// mainnet upgrades
 	V010405UpgradeName = "v1.4.5"

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -43,6 +43,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010404rc4UpgradeName, CreateUpgradeHandler: NoOpHandler},
 		{UpgradeName: V010405rc2UpgradeName, CreateUpgradeHandler: NoOpHandler},
 		{UpgradeName: V010405rc3UpgradeName, CreateUpgradeHandler: NoOpHandler},
+		{UpgradeName: V010405rc4UpgradeName, CreateUpgradeHandler: NoOpHandler},
 		{UpgradeName: V010405UpgradeName, CreateUpgradeHandler: NoOpHandler},
 	}
 }


### PR DESCRIPTION
## 1. Summary
Add's a no-op upgradehandler to facilitate the upgrade to v1.4.5-rc4 of the rhye-2 testnet.
