### PR TITLE
fix: we should still set intent when we have zero existing claims

### DIFF
--- a/x/interchainstaking/keeper/intent.go
+++ b/x/interchainstaking/keeper/intent.go
@@ -209,9 +209,6 @@ func (k *Keeper) UpdateDelegatorIntent(ctx sdk.Context, delegator sdk.AccAddress
 
 	// inAmount is ordinal with respect to the redemption rate, so we must scale
 	baseBalance := zone.RedemptionRate.Mul(sdk.NewDecFromInt(claimAmt))
-	if baseBalance.IsZero() {
-		return nil
-	}
 
 	if updateWithCoin {
 		delIntent = zone.UpdateIntentWithCoins(delIntent, baseBalance, inAmount, utils.StringSliceToMap(k.GetValidatorAddresses(ctx, zone.ChainId)))

--- a/x/interchainstaking/types/zones_test.go
+++ b/x/interchainstaking/types/zones_test.go
@@ -308,6 +308,34 @@ func TestUpdateIntentWithMemo(t *testing.T) {
 				"cosmosvaloper14lultfckehtszvzw4ehu0apvsr77afvyju5zzy": sdk.NewDecWithPrec(15, 2),
 			},
 		},
+		{
+			baseAmount: 0,
+			originalIntent: map[string]sdk.Dec{
+				"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0": sdk.NewDecWithPrec(45, 2),
+				"cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf": sdk.NewDecWithPrec(55, 2),
+			},
+			memo: "AipahL/4TH3a0Ry4wHOG6RkoxWdcpLxuppAElPH3PNriuvHIuI/1/AuKM5w=",
+
+			amount: 100,
+			expectedIntent: map[string]sdk.Dec{
+				"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0": sdk.NewDecWithPrec(45, 2),
+				"cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf": sdk.NewDecWithPrec(55, 2),
+			},
+		},
+		{
+			baseAmount: 0,
+			originalIntent: map[string]sdk.Dec{
+				"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0": sdk.NewDecWithPrec(100, 2),
+				"cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf": sdk.NewDecWithPrec(0, 2),
+			},
+			memo: "AipahL/4TH3a0Ry4wHOG6RkoxWdcpLxuppAElPH3PNriuvHIuI/1/AuKM5w=",
+
+			amount: 100,
+			expectedIntent: map[string]sdk.Dec{
+				"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0": sdk.NewDecWithPrec(45, 2),
+				"cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf": sdk.NewDecWithPrec(55, 2),
+			},
+		},
 	}
 
 	for caseidx, tc := range testCases {


### PR DESCRIPTION
## 1. Summary
Fixes #1002 - Ensure setIntent is called correctly even when the user has zero existing claims.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

