### PR TITLE
Release/v1.4.6

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -23,6 +23,7 @@ const (
 	// mainnet upgrades
 	V010217UpgradeName = "v1.2.17"
 	V010405UpgradeName = "v1.4.5"
+	V010406UpgradeName = "v1.4.6"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -25,8 +25,8 @@ func Upgrades() []Upgrade {
 
 		// v1.2: this needs to be present to support upgrade on mainnet
 		{UpgradeName: V010217UpgradeName, CreateUpgradeHandler: NoOpHandler},
-
 		{UpgradeName: V010405UpgradeName, CreateUpgradeHandler: NoOpHandler},
+		{UpgradeName: V010406UpgradeName, CreateUpgradeHandler: V010406UpgradeHandler},
 	}
 }
 
@@ -41,7 +41,7 @@ func NoOpHandler(
 	}
 }
 
-func V010405UpgradeHandler(
+func V010406UpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 	appKeepers *keepers.AppKeepers,
@@ -82,6 +82,7 @@ func V010405UpgradeHandler(
 				query := stakingtypes.QueryValidatorsRequest{}
 				_ = appKeepers.InterchainstakingKeeper.EmitValSetQuery(ctx, zone.ConnectionId, zone.ChainId, query, math.NewInt(-1))
 			}
+
 			zone.Validators = nil
 			appKeepers.InterchainstakingKeeper.SetZone(ctx, zone)
 			return false

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -83,6 +83,11 @@ func V010406UpgradeHandler(
 				_ = appKeepers.InterchainstakingKeeper.EmitValSetQuery(ctx, zone.ConnectionId, zone.ChainId, query, math.NewInt(-1))
 			}
 
+			appKeepers.InterchainstakingKeeper.SetAddressZoneMapping(ctx, zone.DepositAddress.Address, zone.ChainId)
+			appKeepers.InterchainstakingKeeper.SetAddressZoneMapping(ctx, zone.DelegationAddress.Address, zone.ChainId)
+			appKeepers.InterchainstakingKeeper.SetAddressZoneMapping(ctx, zone.PerformanceAddress.Address, zone.ChainId)
+			appKeepers.InterchainstakingKeeper.SetAddressZoneMapping(ctx, zone.WithdrawalAddress.Address, zone.ChainId)
+
 			zone.Validators = nil
 			appKeepers.InterchainstakingKeeper.SetZone(ctx, zone)
 			return false

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -144,8 +144,8 @@ func (s *AppTestSuite) TestV010406UpgradeHandler() {
 	s.InitV146TestZones()
 	app := s.GetQuicksilverApp(s.chainA)
 
-	handler := upgrades.V010406UpgradeHandler(app.mm, 
-app.configurator, &app.AppKeepers)
+	handler := upgrades.V010406UpgradeHandler(app.mm,
+		app.configurator, &app.AppKeepers)
 	ctx := s.chainA.GetContext()
 
 	_, err := handler(ctx, types.Plan{}, app.mm.GetVersionMap())

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -72,7 +72,7 @@ func (s *AppTestSuite) SetupTest() {
 	s.coordinator.UpdateTime()
 }
 
-func (s *AppTestSuite) InitV145TestZones() {
+func (s *AppTestSuite) InitV146TestZones() {
 	// cosmos zone
 	zone := icstypes.Zone{
 		ConnectionId:    "connection-77001",
@@ -140,11 +140,12 @@ func addVestingAccount(ctx sdk.Context, ak *authkeeper.AccountKeeper, address st
 	ak.SetAccount(ctx, vest)
 }
 
-func (s *AppTestSuite) TestV010405UpgradeHandler() {
-	s.InitV145TestZones()
+func (s *AppTestSuite) TestV010406UpgradeHandler() {
+	s.InitV146TestZones()
 	app := s.GetQuicksilverApp(s.chainA)
 
-	handler := upgrades.V010405UpgradeHandler(app.mm, app.configurator, &app.AppKeepers)
+	handler := upgrades.V010406UpgradeHandler(app.mm, 
+app.configurator, &app.AppKeepers)
 	ctx := s.chainA.GetContext()
 
 	_, err := handler(ctx, types.Plan{}, app.mm.GetVersionMap())

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -73,6 +73,11 @@ func (s *AppTestSuite) SetupTest() {
 }
 
 func (s *AppTestSuite) InitV146TestZones() {
+
+	cosmosWithdrawal := addressutils.GenerateAddressForTestWithPrefix("cosmos")
+	cosmosPerformance := addressutils.GenerateAddressForTestWithPrefix("cosmos")
+	cosmosDeposit := addressutils.GenerateAddressForTestWithPrefix("cosmos")
+	cosmosDelegate := addressutils.GenerateAddressForTestWithPrefix("cosmos")
 	// cosmos zone
 	zone := icstypes.Zone{
 		ConnectionId:    "connection-77001",
@@ -82,9 +87,33 @@ func (s *AppTestSuite) InitV146TestZones() {
 		BaseDenom:       "uatom",
 		MultiSend:       false,
 		LiquidityModule: false,
+		WithdrawalAddress: &icstypes.ICAAccount{
+			Address:           cosmosWithdrawal,
+			PortName:          "icacontroller-cosmoshub-4.withdrawal",
+			WithdrawalAddress: cosmosWithdrawal,
+		},
+		DelegationAddress: &icstypes.ICAAccount{
+			Address:           cosmosDelegate,
+			PortName:          "icacontroller-cosmoshub-4.delegate",
+			WithdrawalAddress: cosmosWithdrawal,
+		},
+		DepositAddress: &icstypes.ICAAccount{
+			Address:           cosmosDeposit,
+			PortName:          "icacontroller-cosmoshub-4.deposit",
+			WithdrawalAddress: cosmosWithdrawal,
+		},
+		PerformanceAddress: &icstypes.ICAAccount{
+			Address:           cosmosPerformance,
+			PortName:          "icacontroller-cosmoshub-4.performance",
+			WithdrawalAddress: cosmosWithdrawal,
+		},
 	}
 	s.GetQuicksilverApp(s.chainA).InterchainstakingKeeper.SetZone(s.chainA.GetContext(), &zone)
 
+	osmoWithdrawal := addressutils.GenerateAddressForTestWithPrefix("osmo")
+	osmoPerformance := addressutils.GenerateAddressForTestWithPrefix("osmo")
+	osmoDeposit := addressutils.GenerateAddressForTestWithPrefix("osmo")
+	osmoDelegate := addressutils.GenerateAddressForTestWithPrefix("osmo")
 	// osmosis zone
 	zone = icstypes.Zone{
 		ConnectionId:    "connection-77002",
@@ -94,9 +123,35 @@ func (s *AppTestSuite) InitV146TestZones() {
 		BaseDenom:       "uosmo",
 		MultiSend:       false,
 		LiquidityModule: false,
+		WithdrawalAddress: &icstypes.ICAAccount{
+			Address:           osmoWithdrawal,
+			PortName:          "icacontroller-osmosis-1.withdrawal",
+			WithdrawalAddress: osmoWithdrawal,
+		},
+		DelegationAddress: &icstypes.ICAAccount{
+			Address:           osmoDelegate,
+			PortName:          "icacontroller-osmosis-1.delegate",
+			WithdrawalAddress: osmoWithdrawal,
+		},
+		DepositAddress: &icstypes.ICAAccount{
+			Address:           osmoDeposit,
+			PortName:          "icacontroller-osmosis-1.deposit",
+			WithdrawalAddress: osmoWithdrawal,
+		},
+		PerformanceAddress: &icstypes.ICAAccount{
+			Address:           osmoPerformance,
+			PortName:          "icacontroller-osmosis-1.performance",
+			WithdrawalAddress: osmoWithdrawal,
+		},
 	}
 	s.GetQuicksilverApp(s.chainA).InterchainstakingKeeper.SetZone(s.chainA.GetContext(), &zone)
 	// uni-5 zone
+
+	junoWithdrawal := addressutils.GenerateAddressForTestWithPrefix("juno")
+	junoPerformance := addressutils.GenerateAddressForTestWithPrefix("juno")
+	junoDeposit := addressutils.GenerateAddressForTestWithPrefix("juno")
+	junoDelegate := addressutils.GenerateAddressForTestWithPrefix("juno")
+
 	zone = icstypes.Zone{
 		ConnectionId:    "connection-77003",
 		ChainId:         "juno-1",
@@ -105,6 +160,26 @@ func (s *AppTestSuite) InitV146TestZones() {
 		BaseDenom:       "ujuno",
 		MultiSend:       false,
 		LiquidityModule: false,
+		WithdrawalAddress: &icstypes.ICAAccount{
+			Address:           junoWithdrawal,
+			PortName:          "icacontroller-juno-1.withdrawal",
+			WithdrawalAddress: junoWithdrawal,
+		},
+		DelegationAddress: &icstypes.ICAAccount{
+			Address:           junoDelegate,
+			PortName:          "icacontroller-juno-1.delegate",
+			WithdrawalAddress: junoWithdrawal,
+		},
+		DepositAddress: &icstypes.ICAAccount{
+			Address:           junoDeposit,
+			PortName:          "icacontroller-juno-1.deposit",
+			WithdrawalAddress: junoWithdrawal,
+		},
+		PerformanceAddress: &icstypes.ICAAccount{
+			Address:           junoPerformance,
+			PortName:          "icacontroller-juno-1.performance",
+			WithdrawalAddress: junoWithdrawal,
+		},
 	}
 	s.GetQuicksilverApp(s.chainA).InterchainstakingKeeper.SetZone(s.chainA.GetContext(), &zone)
 
@@ -182,4 +257,17 @@ func (s *AppTestSuite) TestV010406UpgradeHandler() {
 	s.True(ok)
 	s.Equal(int64(1712880000), pva.EndTime)
 	s.Equal(10, len(pva.VestingPeriods))
+
+	ctestZone, found := app.InterchainstakingKeeper.GetZoneForAccount(ctx, cosmosZone.DepositAddress.Address)
+	s.True(found)
+	s.Equal(ctestZone.ChainId, cosmosZone.ChainId)
+
+	otestZone, found := app.InterchainstakingKeeper.GetZoneForAccount(ctx, osmoZone.PerformanceAddress.Address)
+	s.True(found)
+	s.Equal(otestZone.ChainId, osmoZone.ChainId)
+
+	noTestZone, found := app.InterchainstakingKeeper.GetZoneForAccount(ctx, addressutils.GenerateAddressForTestWithPrefix("cosmos"))
+	s.False(found)
+	s.Nil(noTestZone)
+
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -73,7 +73,6 @@ func (s *AppTestSuite) SetupTest() {
 }
 
 func (s *AppTestSuite) InitV146TestZones() {
-
 	cosmosWithdrawal := addressutils.GenerateAddressForTestWithPrefix("cosmos")
 	cosmosPerformance := addressutils.GenerateAddressForTestWithPrefix("cosmos")
 	cosmosDeposit := addressutils.GenerateAddressForTestWithPrefix("cosmos")
@@ -269,5 +268,4 @@ func (s *AppTestSuite) TestV010406UpgradeHandler() {
 	noTestZone, found := app.InterchainstakingKeeper.GetZoneForAccount(ctx, addressutils.GenerateAddressForTestWithPrefix("cosmos"))
 	s.False(found)
 	s.Nil(noTestZone)
-
 }

--- a/x/interchainstaking/keeper/callbacks.go
+++ b/x/interchainstaking/keeper/callbacks.go
@@ -275,7 +275,7 @@ func SigningInfoCallback(k *Keeper, ctx sdk.Context, args []byte, query icqtypes
 	valSigningInfo := slashingtypes.ValidatorSigningInfo{}
 	if len(args) == 0 {
 		k.Logger(ctx).Error("unable to find signing info for validator", "query", query.Request)
-		return errors.New("attempted to unmarshal zero length byte slice (10)")
+		return nil
 	}
 	err := k.cdc.Unmarshal(args, &valSigningInfo)
 	if err != nil {

--- a/x/interchainstaking/keeper/callbacks_test.go
+++ b/x/interchainstaking/keeper/callbacks_test.go
@@ -1988,17 +1988,6 @@ func (suite *KeeperTestSuite) TestSigningInfoCallback() {
 			},
 			expectErr: true,
 		},
-		// args has no len
-		{
-			name: "args has no len",
-			malleate: func(quicksilver *app.Quicksilver, ctx sdk.Context) []byte {
-				return []byte{}
-			},
-			query: icqtypes.Query{
-				ChainId: suite.chainB.ChainID,
-			},
-			expectErr: true,
-		},
 		// wrong type args
 		{
 			name: "wrong type args",


### PR DESCRIPTION
## 1. Summary
Fixes v1.4.5 failed upgrade.

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

The upgrade handler for v1.4.5 release did not execute, as the registered handler reference a no-op handler (i.e. has not impact), rather than one that made the relevant state transitions.

As such, a number of important state transitions were not applied.

Additionally, missing from said upgrade handler were called to SetZoneAddressMapping() which allows for more efficient lookups of zone from ICAAddresses.

This PR updates the v1.4.5 upgrade handler that was not applied to be executed on v1.4.6, with the additional of calling SetZoneAddressMapping once for each of the ICA addresses controlled on each zone.