### PR TITLE
auto add local denom for onboarded zone

### DIFF
--- a/x/interchainstaking/keeper/proposal_handler.go
+++ b/x/interchainstaking/keeper/proposal_handler.go
@@ -101,7 +101,7 @@ func (k *Keeper) HandleRegisterZoneProposal(ctx sdk.Context, p *types.RegisterZo
 		return err
 	}
 
-	err = k.hooks.AfterZoneCreated(ctx, zone.ConnectionId, zone.ChainId, zone.AccountPrefix)
+	err = k.hooks.AfterZoneCreated(ctx, zone)
 	if err != nil {
 		return err
 	}

--- a/x/interchainstaking/types/expected_keepers.go
+++ b/x/interchainstaking/types/expected_keepers.go
@@ -42,7 +42,7 @@ type BankKeeper interface {
 }
 
 type IcsHooks interface {
-	AfterZoneCreated(ctx sdk.Context, connectionID, chainID, accountPrefix string) error
+	AfterZoneCreated(ctx sdk.Context, zone *Zone) error
 }
 
 type ClaimsManagerKeeper interface {

--- a/x/interchainstaking/types/hooks.go
+++ b/x/interchainstaking/types/hooks.go
@@ -13,9 +13,9 @@ func NewMultiIcsHooks(hooks ...IcsHooks) MultiIcsHooks {
 	return hooks
 }
 
-func (h MultiIcsHooks) AfterZoneCreated(ctx sdk.Context, connectionID, chainID, accountPrefix string) error {
+func (h MultiIcsHooks) AfterZoneCreated(ctx sdk.Context, zone *Zone) error {
 	for i := range h {
-		if err := h[i].AfterZoneCreated(ctx, connectionID, chainID, accountPrefix); err != nil {
+		if err := h[i].AfterZoneCreated(ctx, zone); err != nil {
 			return err
 		}
 	}

--- a/x/participationrewards/keeper/hooks_test.go
+++ b/x/participationrewards/keeper/hooks_test.go
@@ -1,0 +1,31 @@
+package keeper_test
+
+import (
+	icstypes "github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
+	"github.com/quicksilver-zone/quicksilver/x/participationrewards/types"
+)
+
+func (suite *KeeperTestSuite) TestAfterZoneCreated() {
+	zone := &icstypes.Zone{
+		ChainId:       "testzone-1",
+		ConnectionId:  "connection-0",
+		AccountPrefix: "test",
+		LocalDenom:    "uqtst",
+		BaseDenom:     "utst",
+	}
+	suite.Run("ProtocolData", func() {
+		k := suite.GetQuicksilverApp(suite.chainA).ParticipationRewardsKeeper
+		ctx := suite.chainA.GetContext()
+		suite.NoError(k.Hooks().AfterZoneCreated(ctx, zone))
+		ctx = suite.chainA.GetContext()
+		// we want to fetch this for the local (quicksilver) zone; not the host chain.
+		pd, found := k.GetProtocolData(ctx, types.ProtocolDataTypeLiquidToken, ctx.ChainID()+"_"+zone.LocalDenom)
+		suite.True(found)
+		upd, err := types.UnmarshalProtocolData(types.ProtocolDataTypeLiquidToken, pd.Data)
+		suite.NoError(err)
+		lpd := upd.(*types.LiquidAllowedDenomProtocolData)
+		suite.Equal(zone.ChainId, lpd.RegisteredZoneChainID)
+		suite.Equal(zone.LocalDenom, lpd.QAssetDenom)
+		suite.Equal(ctx.ChainID(), lpd.ChainID)
+	})
+}

--- a/x/participationrewards/keeper/protocol_data.go
+++ b/x/participationrewards/keeper/protocol_data.go
@@ -89,7 +89,3 @@ func (k *Keeper) AllKeyedProtocolDatas(ctx sdk.Context) []*types.KeyedProtocolDa
 	})
 	return out
 }
-
-/* func GetProtocolDataKey(protocol string, key string) string {
-	return fmt.Sprintf("%s/%s", protocol, key)
-} */


### PR DESCRIPTION
## 1. Summary
Fixes #1121  - auto add local denom protocol data for newly registered zone.

## 2.Type of change

- [x] New feature (non-breaking change which adds functionality)

## 3. Implementation details

Protocol data must be added for all onboarded zones; however the protocol data for Connections and LocalDenom can, and should be automatically added on registration, as we have the details on hand to do so.

In the participation rewards AfterZoneCreated hook, we trigger the registration of LiquidAllowedDenomProtocolData for the Quicksilver chain, for the local qAsset denom.

This will allow claiming for local assets immediately from the first epoch after onboarding.

Note: the signature of the AfterZoneCreated() hook was changed to pass the `*Zone` instead of connectionId, ChainId and AccountPrefix to allow for greater functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced consistency in zone creation handling across the system.
	- Improved data validation and storage mechanisms for zone creation events.
	- Removed unnecessary commented-out function for protocol data retrieval.
- **Tests**
	- Added a test function to verify zone creation behavior in the participation rewards keeper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->