### PR TITLE
Handle condition if query ttl maybe out of range int64 and added unit test for it

### DIFF
--- a/x/interchainquery/keeper/abci.go
+++ b/x/interchainquery/keeper/abci.go
@@ -17,7 +17,7 @@ const (
 // EndBlocker of interchainquery module.
 func (k Keeper) EndBlocker(ctx sdk.Context) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
-	_ = k.Logger(ctx)
+
 	events := sdk.Events{}
 	// emit events for periodic queries
 	k.IterateQueries(ctx, func(_ int64, queryInfo types.Query) (stop bool) {
@@ -58,7 +58,7 @@ func (k Keeper) EndBlocker(ctx sdk.Context) {
 		if !found {
 			// query was removed; delete datapoint
 			k.DeleteDatapoint(ctx, dp.Id)
-		} else if dp.LocalHeight.Int64()+int64(q.Ttl) > ctx.BlockHeader().Height {
+		} else if dp.LocalHeight.Add(sdk.NewIntFromUint64(q.Ttl)).Sub(sdk.NewInt(ctx.BlockHeader().Height)).IsPositive() {
 			// gc old data
 			k.DeleteDatapoint(ctx, dp.Id)
 		}


### PR DESCRIPTION
## 1. Summary
<!-- What are you changing, removing, or adding in this review? -->
Seems that `Ttl` of a `Query` is setable value and maybe out of bound int64, so the old condition `dp.LocalHeight.Int64()+int64(q.Ttl) > ctx.BlockHeader().Height` will wrong and the old data point will not be removed.

This PR using `math.Int` for compute condition, avoid direct casting `uint64` to `int64`.

## 2.Type of change

<!--  Please delete options that are not relevant. -->

## 3. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 4. How to test/use

<!-- How can people test/use this? -->

## 5. Checklist

<!-- Checklist for PR author(s). -->

## 6. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 7. Future Work (optional)

<!-- Describe follow-up work, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of datapoints in the interchain query module, including enhanced garbage collection based on specified conditions.
- **Bug Fixes**
	- Addressed issues with handling out-of-bound Time-to-Live (TTL) values in interchain queries.
- **Tests**
	- Added new tests to ensure robust handling of out-of-bound TTL values in interchain queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->