### PR TITLE
fixes: #1169; add callback ID to query hash generation

### DIFF
--- a/x/interchainquery/genesis_test.go
+++ b/x/interchainquery/genesis_test.go
@@ -70,7 +70,7 @@ func (s *InterChainQueryTestSuite) TestInitGenesis() {
 
 	interchainquery.InitGenesis(s.chainA.GetContext(), s.GetSimApp(s.chainA).InterchainQueryKeeper, types.GenesisState{Queries: []types.Query{*query}})
 
-	id := keeper.GenerateQueryHash(s.path.EndpointB.ConnectionID, s.chainB.ChainID, "cosmos.staking.v1beta1.Query/Validators", bz, "")
+	id := keeper.GenerateQueryHash(s.path.EndpointB.ConnectionID, s.chainB.ChainID, "cosmos.staking.v1beta1.Query/Validators", bz, "", "")
 	queryResponse, found := s.GetSimApp(s.chainA).InterchainQueryKeeper.GetQuery(s.chainA.GetContext(), id)
 	s.True(found)
 	s.Equal(s.path.EndpointB.ConnectionID, queryResponse.ConnectionId)

--- a/x/interchainquery/keeper/keeper.go
+++ b/x/interchainquery/keeper/keeper.go
@@ -75,7 +75,7 @@ func (k *Keeper) MakeRequest(
 		"callback", callbackID,
 		"ttl", ttl,
 	)
-	key := GenerateQueryHash(connectionID, chainID, queryType, request, module)
+	key := GenerateQueryHash(connectionID, chainID, queryType, request, module, callbackID)
 	existingQuery, found := k.GetQuery(ctx, key)
 	if !found {
 		if module != "" && callbackID != "" {

--- a/x/interchainquery/keeper/keeper_test.go
+++ b/x/interchainquery/keeper/keeper_test.go
@@ -71,7 +71,7 @@ func (suite *KeeperTestSuite) TestMakeRequest() {
 		0,
 	)
 
-	id := keeper.GenerateQueryHash(suite.path.EndpointB.ConnectionID, suite.chainB.ChainID, "cosmos.staking.v1beta1.Query/Validators", bz, "")
+	id := keeper.GenerateQueryHash(suite.path.EndpointB.ConnectionID, suite.chainB.ChainID, "cosmos.staking.v1beta1.Query/Validators", bz, "", "")
 	query, found := suite.GetSimApp(suite.chainA).InterchainQueryKeeper.GetQuery(suite.chainA.GetContext(), id)
 	suite.True(found)
 	suite.Equal(suite.path.EndpointB.ConnectionID, query.ConnectionId)
@@ -179,7 +179,7 @@ func (suite *KeeperTestSuite) TestSubmitQueryResponse() {
 
 		qmsg := icqtypes.MsgSubmitQueryResponse{
 			ChainId:     suite.chainB.ChainID,
-			QueryId:     keeper.GenerateQueryHash(tc.query.ConnectionId, tc.query.ChainId, tc.query.QueryType, bz, ""),
+			QueryId:     keeper.GenerateQueryHash(tc.query.ConnectionId, tc.query.ChainId, tc.query.QueryType, bz, "", ""),
 			Result:      suite.GetSimApp(suite.chainB).AppCodec().MustMarshalJSON(&qvr),
 			Height:      suite.chainB.CurrentHeader.Height,
 			FromAddress: TestOwnerAddress,

--- a/x/interchainquery/keeper/queries.go
+++ b/x/interchainquery/keeper/queries.go
@@ -13,8 +13,8 @@ import (
 	"github.com/quicksilver-zone/quicksilver/x/interchainquery/types"
 )
 
-func GenerateQueryHash(connectionID, chainID, queryType string, request []byte, module string) string {
-	return fmt.Sprintf("%x", crypto.Sha256(append([]byte(module+connectionID+chainID+queryType), request...)))
+func GenerateQueryHash(connectionID, chainID, queryType string, request []byte, module string, callbackID string) string {
+	return fmt.Sprintf("%x", crypto.Sha256(append([]byte(module+connectionID+chainID+queryType+callbackID), request...)))
 }
 
 // ----------------------------------------------------------------
@@ -30,7 +30,7 @@ func (k Keeper) NewQuery(
 	ttl uint64,
 ) *types.Query {
 	return &types.Query{
-		Id:           GenerateQueryHash(connectionID, chainID, queryType, request, module),
+		Id:           GenerateQueryHash(connectionID, chainID, queryType, request, module, callbackID),
 		ConnectionId: connectionID,
 		ChainId:      chainID,
 		QueryType:    queryType,

--- a/x/interchainquery/keeper/queries_test.go
+++ b/x/interchainquery/keeper/queries_test.go
@@ -27,7 +27,7 @@ func (suite *KeeperTestSuite) TestQuery() {
 	suite.GetSimApp(suite.chainA).InterchainQueryKeeper.SetQuery(suite.chainA.GetContext(), *query)
 
 	// get the stored query
-	id := keeper.GenerateQueryHash(query.ConnectionId, query.ChainId, query.QueryType, query.Request, "")
+	id := keeper.GenerateQueryHash(query.ConnectionId, query.ChainId, query.QueryType, query.Request, "", "")
 	getQuery, found := suite.GetSimApp(suite.chainA).InterchainQueryKeeper.GetQuery(suite.chainA.GetContext(), id)
 	suite.True(found)
 	suite.Equal(suite.path.EndpointB.ConnectionID, getQuery.ConnectionId)

--- a/x/interchainquery/types/msgs_test.go
+++ b/x/interchainquery/types/msgs_test.go
@@ -63,7 +63,7 @@ func TestMsgSubmitQueryResponse(t *testing.T) {
 
 	msg := types.MsgSubmitQueryResponse{
 		ChainId:     chainB.ChainID + "-N",
-		QueryId:     keeper.GenerateQueryHash(path.EndpointB.ConnectionID, chainB.ChainID, "cosmos.staking.v1beta1.Query/Validators", bz, ""),
+		QueryId:     keeper.GenerateQueryHash(path.EndpointB.ConnectionID, chainB.ChainID, "cosmos.staking.v1beta1.Query/Validators", bz, "", ""),
 		Result:      GetSimApp(chainB).AppCodec().MustMarshalJSON(&qvr),
 		Height:      chainB.CurrentHeader.Height,
 		FromAddress: testAddress.String(),

--- a/x/participationrewards/keeper/callbacks_test.go
+++ b/x/participationrewards/keeper/callbacks_test.go
@@ -25,7 +25,7 @@ func (suite *KeeperTestSuite) executeOsmosisPoolUpdateCallback() {
 	ctx := suite.chainA.GetContext()
 
 	osm := &keeper.OsmosisModule{}
-	qid := icqkeeper.GenerateQueryHash("connection-77002", "osmosis-1", "store/gamm/key", osm.GetKeyPrefixPools(1), types.ModuleName)
+	qid := icqkeeper.GenerateQueryHash("connection-77002", "osmosis-1", "store/gamm/key", osm.GetKeyPrefixPools(1), types.ModuleName, keeper.OsmosisPoolUpdateCallbackID)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
 	suite.True(found, "qid: %s", qid)
@@ -85,6 +85,7 @@ func (suite *KeeperTestSuite) executeValidatorSelectionRewardsCallback(performan
 		"cosmos.distribution.v1beta1.Query/DelegationTotalRewards",
 		bz,
 		types.ModuleName,
+		keeper.ValidatorSelectionRewardsCallbackID,
 	)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
@@ -131,6 +132,7 @@ func (suite *KeeperTestSuite) executeSetEpochBlockCallback() {
 		"cosmos.base.tendermint.v1beta1.Service/GetLatestBlock",
 		bz,
 		types.ModuleName,
+		keeper.SetEpochBlockCallbackID,
 	)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
@@ -155,7 +157,7 @@ func (suite *KeeperTestSuite) executeUmeeReservesUpdateCallback() {
 	prk := suite.GetQuicksilverApp(suite.chainA).ParticipationRewardsKeeper
 	ctx := suite.chainA.GetContext()
 
-	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyReserveAmount(umeeBaseDenom), types.ModuleName)
+	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyReserveAmount(umeeBaseDenom), types.ModuleName, keeper.UmeeReservesUpdateCallbackID)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
 	suite.True(found, "qid: %s", qid)
@@ -199,7 +201,7 @@ func (suite *KeeperTestSuite) executeUmeeLeverageModuleBalanceUpdateCallback() {
 
 	accountPrefix := banktypes.CreateAccountBalancesPrefix(authtypes.NewModuleAddress(leveragetypes.LeverageModuleName))
 
-	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/bank/key", append(accountPrefix, []byte(umeeBaseDenom)...), types.ModuleName)
+	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/bank/key", append(accountPrefix, []byte(umeeBaseDenom)...), types.ModuleName, keeper.UmeeLeverageModuleBalanceUpdateCallbackID)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
 	suite.True(found, "qid: %s", qid)
@@ -241,7 +243,7 @@ func (suite *KeeperTestSuite) executeUmeeUTokenSupplyUpdateCallback() {
 	prk := suite.GetQuicksilverApp(suite.chainA).ParticipationRewardsKeeper
 	ctx := suite.chainA.GetContext()
 
-	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyUTokenSupply(leveragetypes.UTokenPrefix+umeeBaseDenom), types.ModuleName)
+	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyUTokenSupply(leveragetypes.UTokenPrefix+umeeBaseDenom), types.ModuleName, keeper.UmeeUTokenSupplyUpdateCallbackID)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
 	suite.True(found, "qid: %s", qid)
@@ -283,7 +285,7 @@ func (suite *KeeperTestSuite) executeUmeeTotalBorrowsUpdateCallback() {
 	prk := suite.GetQuicksilverApp(suite.chainA).ParticipationRewardsKeeper
 	ctx := suite.chainA.GetContext()
 
-	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyAdjustedTotalBorrow(umeeBaseDenom), types.ModuleName)
+	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyAdjustedTotalBorrow(umeeBaseDenom), types.ModuleName, keeper.UmeeTotalBorrowsUpdateCallbackID)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
 	suite.True(found, "qid: %s", qid)
@@ -325,7 +327,7 @@ func (suite *KeeperTestSuite) executeUmeeInterestScalarUpdateCallback() {
 	prk := suite.GetQuicksilverApp(suite.chainA).ParticipationRewardsKeeper
 	ctx := suite.chainA.GetContext()
 
-	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyInterestScalar(umeeBaseDenom), types.ModuleName)
+	qid := icqkeeper.GenerateQueryHash(umeeTestConnection, umeeTestChain, "store/leverage/key", leveragetypes.KeyInterestScalar(umeeBaseDenom), types.ModuleName, keeper.UmeeInterestScalarUpdateCallbackID)
 
 	query, found := prk.IcqKeeper.GetQuery(ctx, qid)
 	suite.True(found, "qid: %s", qid)


### PR DESCRIPTION
## 1. Summary
Fixes #1169 

This change adds the callbackID as part of the generated key used to identify hashes, This allows to otherwise identical requests to exist with different callbacks.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Add an additional argument to GenerateQueryHash() allowing the inclusion of the callback ID in the key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the query hash generation to include `callbackID`, improving query uniqueness and handling.
- **Refactor**
	- Updated query generation logic to incorporate `callbackID` in key generation for better query management.
- **Tests**
	- Modified tests to accommodate the inclusion of `callbackID` in the hash generation process and ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->