### PR TITLE
add v1.5.0-rc0 upgrade handler

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -22,6 +22,7 @@ const (
 	V010407rc0UpgradeName = "v1.4.7-rc0"
 	V010407rc1UpgradeName = "v1.4.7-rc1"
 	V010407rc2UpgradeName = "v1.4.7-rc2"
+	V010500rc0UpgradeName = "v1.5.0-rc0"
 
 	// mainnet upgrades
 	V010217UpgradeName = "v1.2.17"

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -27,6 +27,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010407rc0UpgradeName, CreateUpgradeHandler: NoOpHandler},
 		{UpgradeName: V010407rc1UpgradeName, CreateUpgradeHandler: V010407rc1UpgradeHandler},
 		{UpgradeName: V010407rc2UpgradeName, CreateUpgradeHandler: V010407rc2UpgradeHandler},
+		{UpgradeName: V010500rc0UpgradeName, CreateUpgradeHandler: NoOpHandler},
 
 		// v1.2: this needs to be present to support upgrade on mainnet
 		{UpgradeName: V010217UpgradeName, CreateUpgradeHandler: NoOpHandler},


### PR DESCRIPTION
Add no-op upgrade handler for v1.5.0-rc0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

"""
- **New Features**
	- Introduced support for the new version "v1.5.0-rc0" with a dedicated upgrade handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->