### PR TITLE
remove token from codecov upload; not required for public repo

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -104,7 +104,6 @@ jobs:
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # needed for private repo
           files: ./coverage.txt
           flags: unittests
           fail_ci_if_error: true


### PR DESCRIPTION
## 1. Summary
Fixes dependabot build failures, where it doesn't have access to the codecov token.

Codecov token not required for public repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to enhance security by removing the need for a private access token when uploading coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->