### PR TITLE
refactor: remove storage of chain/connection in context for ibc callbacks

### DIFF
--- a/x/interchainstaking/ibc_module.go
+++ b/x/interchainstaking/ibc_module.go
@@ -1,7 +1,6 @@
 package interchainstaking
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -13,7 +12,6 @@ import (
 	host "github.com/cosmos/ibc-go/v5/modules/core/24-host"
 	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
 
-	"github.com/quicksilver-zone/quicksilver/utils"
 	"github.com/quicksilver-zone/quicksilver/x/interchainstaking/keeper"
 )
 
@@ -126,9 +124,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 		ctx.Logger().Error(err.Error())
 		return err
 	}
-	ctx = ctx.WithContext(context.WithValue(ctx.Context(), utils.ContextKey("connectionID"), connectionID))
-
-	err = im.keeper.HandleAcknowledgement(ctx, packet, acknowledgement)
+	err = im.keeper.HandleAcknowledgement(ctx, packet, acknowledgement, connectionID)
 	if err != nil {
 		im.keeper.Logger(ctx).Error("CALLBACK ERROR:", "error", err.Error())
 	}

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -61,7 +61,7 @@ func DeserializeCosmosTxTyped(cdc codec.BinaryCodec, data []byte) ([]TypedMsg, e
 	return msgs, nil
 }
 
-func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte) error {
+func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte, connectionID string) error {
 	var (
 		ack        channeltypes.Acknowledgement
 		success    bool
@@ -134,7 +134,7 @@ func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Pack
 				return nil
 			}
 			k.Logger(ctx).Info("Rewards withdrawn")
-			if err := k.HandleWithdrawRewards(ctx, msg.Msg); err != nil {
+			if err := k.HandleWithdrawRewards(ctx, msg.Msg, connectionID); err != nil {
 				return err
 			}
 			continue
@@ -155,7 +155,7 @@ func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Pack
 
 			k.Logger(ctx).Info("Tokens redeemed for shares", "response", response)
 			// we should update delegation records here.
-			if err := k.HandleRedeemTokens(ctx, msg.Msg, response.Amount, packetData.Memo); err != nil {
+			if err := k.HandleRedeemTokens(ctx, msg.Msg, response.Amount, packetData.Memo, connectionID); err != nil {
 				return err
 			}
 			continue
@@ -239,7 +239,7 @@ func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Pack
 
 		case "/cosmos.bank.v1beta1.MsgSend":
 			if !success {
-				if err := k.HandleFailedBankSend(ctx, msg.Msg, packetData.Memo); err != nil {
+				if err := k.HandleFailedBankSend(ctx, msg.Msg, packetData.Memo, connectionID); err != nil {
 					k.Logger(ctx).Error("unable to handle failed MsgSend", "error", err)
 					return err
 				}
@@ -254,7 +254,7 @@ func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Pack
 
 			k.Logger(ctx).Info("Funds Transferred", "response", response)
 			// check tokenTransfers - if end user unescrow and burn txs
-			if err := k.HandleCompleteSend(ctx, msg.Msg, packetData.Memo); err != nil {
+			if err := k.HandleCompleteSend(ctx, msg.Msg, packetData.Memo, connectionID); err != nil {
 				return err
 			}
 		case "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress":
@@ -332,7 +332,7 @@ func (k *Keeper) HandleMsgTransfer(ctx sdk.Context, msg ibctransfertypes.Fungibl
 	return k.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, authtypes.FeeCollectorName, balance)
 }
 
-func (k *Keeper) HandleCompleteSend(ctx sdk.Context, msg sdk.Msg, memo string) error {
+func (k *Keeper) HandleCompleteSend(ctx sdk.Context, msg sdk.Msg, memo string, connectionID string) error {
 	k.Logger(ctx).Info("Received MsgSend acknowledgement")
 	// first, type assertion. we should have banktypes.MsgSend
 	sMsg, ok := msg.(*banktypes.MsgSend)
@@ -343,7 +343,7 @@ func (k *Keeper) HandleCompleteSend(ctx sdk.Context, msg sdk.Msg, memo string) e
 	}
 
 	// get zone
-	zone, err := k.GetZoneFromContext(ctx)
+	zone, err := k.GetZoneFromConnectionID(ctx, connectionID)
 	if err != nil {
 		err = fmt.Errorf("2: %w", err)
 		k.Logger(ctx).Error(err.Error())
@@ -768,7 +768,7 @@ func (k *Keeper) HandleUndelegate(ctx sdk.Context, msg sdk.Msg, completion time.
 	return nil
 }
 
-func (k *Keeper) HandleFailedBankSend(ctx sdk.Context, msg sdk.Msg, memo string) error {
+func (k *Keeper) HandleFailedBankSend(ctx sdk.Context, msg sdk.Msg, memo string, connectionID string) error {
 	sMsg, ok := msg.(*banktypes.MsgSend)
 	if !ok {
 		err := errors.New("unable to cast source message to MsgSend")
@@ -777,7 +777,7 @@ func (k *Keeper) HandleFailedBankSend(ctx sdk.Context, msg sdk.Msg, memo string)
 	}
 
 	// get zone
-	zone, err := k.GetZoneFromContext(ctx)
+	zone, err := k.GetZoneFromConnectionID(ctx, connectionID)
 	if err != nil {
 		k.Logger(ctx).Error(err.Error())
 		return err
@@ -907,7 +907,7 @@ func (k *Keeper) HandleFailedUndelegate(ctx sdk.Context, msg sdk.Msg, memo strin
 	return nil
 }
 
-func (k *Keeper) HandleRedeemTokens(ctx sdk.Context, msg sdk.Msg, amount sdk.Coin, memo string) error {
+func (k *Keeper) HandleRedeemTokens(ctx sdk.Context, msg sdk.Msg, amount sdk.Coin, memo string, connectionID string) error {
 	k.Logger(ctx).Info("Received MsgRedeemTokensforShares acknowledgement")
 	// first, type assertion. we should have stakingtypes.MsgRedeemTokensforShares
 	redeemMsg, ok := msg.(*lsmstakingtypes.MsgRedeemTokensForShares)
@@ -915,7 +915,7 @@ func (k *Keeper) HandleRedeemTokens(ctx sdk.Context, msg sdk.Msg, amount sdk.Coi
 		k.Logger(ctx).Error("unable to cast source message to MsgRedeemTokensforShares")
 		return errors.New("unable to cast source message to MsgRedeemTokensforShares")
 	}
-	validatorAddress, err := k.GetValidatorForToken(ctx, redeemMsg.Amount)
+	validatorAddress, err := k.GetValidatorForToken(ctx, redeemMsg.Amount, connectionID)
 	if err != nil {
 		return err
 	}
@@ -1119,8 +1119,8 @@ func (k *Keeper) HandleUpdatedWithdrawAddress(ctx sdk.Context, msg sdk.Msg) erro
 	return nil
 }
 
-func (k *Keeper) GetValidatorForToken(ctx sdk.Context, amount sdk.Coin) (string, error) {
-	zone, err := k.GetZoneFromContext(ctx)
+func (k *Keeper) GetValidatorForToken(ctx sdk.Context, amount sdk.Coin, connectionID string) (string, error) {
+	zone, err := k.GetZoneFromConnectionID(ctx, connectionID)
 	if err != nil {
 		err = fmt.Errorf("3: %w", err)
 		k.Logger(ctx).Error(err.Error())
@@ -1291,14 +1291,14 @@ func (k *Keeper) UpdateDelegationRecordForAddress(
 	return nil
 }
 
-func (k *Keeper) HandleWithdrawRewards(ctx sdk.Context, msg sdk.Msg) error {
+func (k *Keeper) HandleWithdrawRewards(ctx sdk.Context, msg sdk.Msg, connectionID string) error {
 	withdrawalMsg, ok := msg.(*distrtypes.MsgWithdrawDelegatorReward)
 	if !ok {
 		k.Logger(ctx).Error("unable to cast source message to MsgWithdrawDelegatorReward")
 		return errors.New("unable to cast source message to MsgWithdrawDelegatorReward")
 	}
 
-	zone, err := k.GetZoneFromContext(ctx)
+	zone, err := k.GetZoneFromConnectionID(ctx, connectionID)
 	if err != nil {
 		err = fmt.Errorf("4: %w", err)
 		k.Logger(ctx).Error(err.Error())

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -32,7 +32,6 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v5/modules/core/keeper"
 	ibctmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
 
-	"github.com/quicksilver-zone/quicksilver/utils"
 	"github.com/quicksilver-zone/quicksilver/utils/addressutils"
 	epochskeeper "github.com/quicksilver-zone/quicksilver/x/epochs/keeper"
 	interchainquerykeeper "github.com/quicksilver-zone/quicksilver/x/interchainquery/keeper"
@@ -492,15 +491,6 @@ func (k *Keeper) GetChainID(ctx sdk.Context, connectionID string) (string, error
 	}
 
 	return client.ChainId, nil
-}
-
-func (k *Keeper) GetChainIDFromContext(ctx sdk.Context) (string, error) {
-	connectionID := ctx.Context().Value(utils.ContextKey("connectionID"))
-	if connectionID == nil {
-		return "", errors.New("connectionID not in context")
-	}
-
-	return k.GetChainID(ctx, connectionID.(string))
 }
 
 func (k *Keeper) EmitPerformanceBalanceQuery(ctx sdk.Context, zone *types.Zone) error {

--- a/x/interchainstaking/keeper/keeper_test.go
+++ b/x/interchainstaking/keeper/keeper_test.go
@@ -1,8 +1,6 @@
 package keeper_test
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -22,11 +20,9 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v5/testing"
 
 	"github.com/quicksilver-zone/quicksilver/app"
-	"github.com/quicksilver-zone/quicksilver/utils"
 	"github.com/quicksilver-zone/quicksilver/utils/addressutils"
 	"github.com/quicksilver-zone/quicksilver/utils/randomutils"
 	ics "github.com/quicksilver-zone/quicksilver/x/interchainstaking"
-	interchainstakingkeeper "github.com/quicksilver-zone/quicksilver/x/interchainstaking/keeper"
 	icstypes "github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
 )
 
@@ -667,54 +663,6 @@ func (suite *KeeperTestSuite) TestOverrideRedemptionRateNoCap() {
 	suite.True(found)
 
 	suite.Equal(sdk.NewDecWithPrec(676666666666666667, 18), zone.RedemptionRate)
-}
-
-func (suite *KeeperTestSuite) TestGetChainIDFromContext() {
-	testCase := []struct {
-		name            string
-		setup           func() (*interchainstakingkeeper.Keeper, sdk.Context)
-		wantErr         bool
-		expectedErr     error
-		expectedChainID string
-	}{
-		{
-			name: "connectionID not in context",
-			setup: func() (*interchainstakingkeeper.Keeper, sdk.Context) {
-				suite.SetupTest()
-				suite.setupTestZones()
-				return suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper, suite.chainA.GetContext()
-			},
-			wantErr:     true,
-			expectedErr: errors.New("connectionID not in context"),
-		},
-		{
-			name: "get chainID success",
-			setup: func() (*interchainstakingkeeper.Keeper, sdk.Context) {
-				suite.SetupTest()
-				suite.setupTestZones()
-				ctx := suite.chainA.GetContext()
-
-				ctx = ctx.WithContext(context.WithValue(ctx.Context(), utils.ContextKey("connectionID"), suite.path.EndpointA.ConnectionID))
-				return suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper, ctx
-			},
-			wantErr:         false,
-			expectedErr:     nil,
-			expectedChainID: "testchain2",
-		},
-	}
-	for _, tc := range testCase {
-		suite.Run(tc.name, func() {
-			keeper, ctx := tc.setup()
-
-			chainID, err := keeper.GetChainIDFromContext(ctx)
-			if tc.wantErr {
-				suite.Equal(tc.expectedErr, err)
-				return
-			}
-			suite.NoError(err)
-			suite.Equal(tc.expectedChainID, chainID)
-		})
-	}
 }
 
 func (suite *KeeperTestSuite) TestIteratePortConnection() {

--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -132,6 +132,21 @@ func (k *Keeper) GetZoneFromContext(ctx sdk.Context) (*types.Zone, error) {
 	return &zone, nil
 }
 
+// GetZoneFromConnectionID determines the zone from the connection ID
+func (k *Keeper) GetZoneFromConnectionID(ctx sdk.Context, connectionID string) (*types.Zone, error) {
+	chainID, err := k.GetChainID(ctx, connectionID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch zone from context: %w", err)
+	}
+	zone, found := k.GetZone(ctx, chainID)
+	if !found {
+		err := fmt.Errorf("unable to fetch zone from context: not found for chainID %s", chainID)
+		k.Logger(ctx).Error(err.Error())
+		return nil, err
+	}
+	return &zone, nil
+}
+
 func (k *Keeper) GetZoneForAccount(ctx sdk.Context, address string) (*types.Zone, bool) {
 	chainID, found := k.GetAddressZoneMapping(ctx, address)
 	if !found {

--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -136,11 +136,11 @@ func (k *Keeper) GetZoneFromContext(ctx sdk.Context) (*types.Zone, error) {
 func (k *Keeper) GetZoneFromConnectionID(ctx sdk.Context, connectionID string) (*types.Zone, error) {
 	chainID, err := k.GetChainID(ctx, connectionID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch zone from context: %w", err)
+		return nil, fmt.Errorf("unable to fetch zone from connection id: %w", err)
 	}
 	zone, found := k.GetZone(ctx, chainID)
 	if !found {
-		err := fmt.Errorf("unable to fetch zone from context: not found for chainID %s", chainID)
+		err := fmt.Errorf("unable to fetch zone from connection id: not found for chainID %s", chainID)
 		k.Logger(ctx).Error(err.Error())
 		return nil, err
 	}

--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -117,21 +117,6 @@ func (k *Keeper) AllZones(ctx sdk.Context) []types.Zone {
 	return zones
 }
 
-// GetZoneFromContext determines the zone from the current context.
-func (k *Keeper) GetZoneFromContext(ctx sdk.Context) (*types.Zone, error) {
-	chainID, err := k.GetChainIDFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch zone from context: %w", err)
-	}
-	zone, found := k.GetZone(ctx, chainID)
-	if !found {
-		err := fmt.Errorf("unable to fetch zone from context: not found for chainID %s", chainID)
-		k.Logger(ctx).Error(err.Error())
-		return nil, err
-	}
-	return &zone, nil
-}
-
 // GetZoneFromConnectionID determines the zone from the connection ID
 func (k *Keeper) GetZoneFromConnectionID(ctx sdk.Context, connectionID string) (*types.Zone, error) {
 	chainID, err := k.GetChainID(ctx, connectionID)


### PR DESCRIPTION

## 1. Summary
Fixes #1054 
<!-- What are you changing, removing, or adding in this review? -->

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 4. How to test/use

<!-- How can people test/use this? -->

## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 6. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 7. Future Work (optional)

<!-- Describe follow-up work, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new function `GetZoneFromConnectionID` to retrieve a zone based on a connection ID in the `Keeper` struct.

- **Enhancements**
	- Improved the handling of acknowledgments and rewards in the interchain staking process.

- **Bug Fixes**
	- Corrected the handling of connection-specific operations in staking transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->