### PR TITLE
fix(claimsmanager): properly check index to avoid invalid data in UserClaims,UserLastEpochClaims

### DIFF
--- a/x/claimsmanager/keeper/grpc_query.go
+++ b/x/claimsmanager/keeper/grpc_query.go
@@ -68,10 +68,17 @@ func (k Keeper) UserClaims(c context.Context, q *types.QueryClaimsRequest) (*typ
 	addrBytes := []byte(q.Address)
 
 	k.IterateAllClaims(ctx, func(_ int64, key []byte, claim types.Claim) (stop bool) {
+		// The assumption is that IterateAllClaims returns non-empty keys.
 		// check for the presence of the addr bytes in the key.
-		// first prefix byte is 0x00; so cater for that! Then + 1 to skip the separator.
-		idx := bytes.Index(key[1:], []byte{0x00}) + 1 + 1
-		if idx >= 0 && bytes.Equal(key[idx:idx+len(addrBytes)], addrBytes) {
+		// first prefix byte is 0x00; so cater for that!
+		idx := bytes.Index(key[1:], []byte{0x00})
+		if idx < 0 {
+			return false
+		}
+
+		idx += 1 + 1 // add + 1 to skip the separator.
+
+		if bytes.Equal(key[idx:idx+len(addrBytes)], addrBytes) {
 			out = append(out, claim)
 		}
 		return false
@@ -86,9 +93,15 @@ func (k Keeper) UserLastEpochClaims(c context.Context, q *types.QueryClaimsReque
 	addrBytes := []byte(q.Address)
 	k.IterateAllLastEpochClaims(ctx, func(_ int64, key []byte, claim types.Claim) (stop bool) {
 		// check for the presence of the addr bytes in the key.
-		// First byte is 0x01 here, so no need to consider it; + 1 to skip the separator.
-		idx := bytes.Index(key, []byte{0x00}) + 1
-		if idx >= 0 && bytes.Equal(key[idx:idx+len(addrBytes)], addrBytes) {
+		idx := bytes.Index(key, []byte{0x00})
+		if idx < 0 {
+			return false
+		}
+
+		// First byte was 0x01, so no need to consider it; + 1 to skip the separator.
+		idx += 1
+
+		if bytes.Equal(key[idx:idx+len(addrBytes)], addrBytes) {
 			out = append(out, claim)
 		}
 		return false


### PR DESCRIPTION
This change ensures that we correctly check for missing values in keeper.(UserClaims, UserLastEpochClaims) because otherwise due to the blind assumption that the key would always be well formed, +1 and +1+1 were being added respectively which would mean that the condition "idx >= 0" would ALWAYS pass and send over the wrong data if the key happened to contain the address bytes.

Fixes #1217
Supersedes PR #1223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the accuracy of claims data processing by adjusting key index calculations and byte comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->