### PR TITLE
fix: unbonding records have nil amount field, so query burnAmount instead

### DIFF
--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -111,12 +111,11 @@ func (k *Keeper) GetUnbondingTokensAndCount(ctx sdk.Context, zone *types.Zone) (
 }
 
 func (k *Keeper) GetQueuedTokensAndCount(ctx sdk.Context, zone *types.Zone) (sdk.Coin, uint32) {
-	out := sdk.NewCoin(zone.BaseDenom, sdk.ZeroInt())
+	out := sdk.NewCoin(zone.LocalDenom, sdk.ZeroInt())
 	var count uint32
 	k.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, types.WithdrawStatusQueued, func(index int64, wr types.WithdrawalRecord) (stop bool) {
-		amount := wr.Amount[0]
-		if !amount.IsNegative() {
-			out = out.Add(amount)
+		if !wr.BurnAmount.IsNegative() {
+			out = out.Add(wr.BurnAmount)
 		}
 		count++
 		return false


### PR DESCRIPTION
## 1. Summary
Fixes #1246 

Use BurnAmount field instead of Amount as amount is nil for an unbonding record.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

Instead of summing the Amount fields of queued withdrawal records, we should use the BurnAmount field, as amount is always nil
for a queued item.

@tropicaldog - FYI