### PR TITLE
add upgrade handler for v1.5.1; fixes #1273; fixes #1274

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -31,6 +31,7 @@ const (
 	V010406UpgradeName = "v1.4.6"
 	V010407UpgradeName = "v1.4.7"
 	V010500UpgradeName = "v1.5.0"
+	V010501UpgradeName = "v1.5.1"
 	V010600UpgradeName = "v1.6.0"
 )
 

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -25,6 +25,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010406UpgradeName, CreateUpgradeHandler: V010406UpgradeHandler},
 		{UpgradeName: V010407UpgradeName, CreateUpgradeHandler: V010407UpgradeHandler},
 		{UpgradeName: V010500UpgradeName, CreateUpgradeHandler: V010500UpgradeHandler},
+		{UpgradeName: V010501UpgradeName, CreateUpgradeHandler: V010501UpgradeHandler},
 		{UpgradeName: V010600UpgradeName, CreateUpgradeHandler: V010600UpgradeHandler},
 	}
 }

--- a/app/upgrades/v1_5.go
+++ b/app/upgrades/v1_5.go
@@ -57,7 +57,6 @@ func V010501UpgradeHandler(
 	appKeepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-
 		// update claims denoms
 		if err := resetLiquidClaimsDenoms(ctx, appKeepers); err != nil {
 			panic(err)
@@ -70,7 +69,6 @@ func V010501UpgradeHandler(
 		})
 
 		return mm.RunMigrations(ctx, configurator, fromVM)
-
 	}
 }
 


### PR DESCRIPTION
## 1. Summary
Fixes #1273 
Fixes #1274
<!-- What are you changing, removing, or adding in this review? -->

## 2.Type of change

- [x] Upgrade handler

## 3. Implementation details

- Upgrade handler resets all the liquid allow denoms with the correct ibc denoms.
- Upgrade handler updates all status 0 records on cosmoshub-4 with status 2 (queued).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced system upgrade to version v1.5.1, improving the handling and calculation of IBC denominations for assets.
- **Bug Fixes**
	- Corrected the parameters order affecting IBC denomination calculations in the upgrade process.
- **Tests**
	- Added tests to ensure the upgrade process correctly handles participation rewards and protocol data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->