### PR TITLE
Avoid panic on nil allocation

### DIFF
--- a/x/participationrewards/keeper/hooks.go
+++ b/x/participationrewards/keeper/hooks.go
@@ -76,7 +76,7 @@ func (k *Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64)
 
 	if allocation == nil {
 		// if allocation is unset, then return early to avoid panic
-		k.Logger(ctx).Error("nil allocation", "error", err.Error())
+		k.Logger(ctx).Error("nil allocation")
 		return nil
 	}
 


### PR DESCRIPTION
## 1. Summary
Fixes #1277

Remove reference to err.Error() in log message when no error is present.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Remove reference in log message to err when err is always nil.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified error handling in the rewards distribution process after an epoch ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->