### PR TITLE
add v1.5.3 and v1.5.3-rc3 upgrade hhandlers

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -24,6 +24,7 @@ const (
 	V010407rc2UpgradeName = "v1.4.7-rc2"
 	V010500rc0UpgradeName = "v1.5.0-rc0"
 	V010500rc1UpgradeName = "v1.5.0-rc1"
+	V010503rc0UpgradeName = "v1.5.3-rc0"
 
 	// mainnet upgrades
 	V010217UpgradeName = "v1.2.17"
@@ -32,6 +33,7 @@ const (
 	V010407UpgradeName = "v1.4.7"
 	V010500UpgradeName = "v1.5.0"
 	V010501UpgradeName = "v1.5.1"
+	V010503UpgradeName = "v1.5.3"
 	V010600UpgradeName = "v1.6.0"
 )
 

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -18,6 +18,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010407rc2UpgradeName, CreateUpgradeHandler: V010407rc2UpgradeHandler},
 		{UpgradeName: V010500rc0UpgradeName, CreateUpgradeHandler: NoOpHandler},
 		{UpgradeName: V010500rc1UpgradeName, CreateUpgradeHandler: V010500rc1UpgradeHandler},
+		{UpgradeName: V010503rc0UpgradeName, CreateUpgradeHandler: V010503rc0UpgradeHandler},
 
 		// v1.2: this needs to be present to support upgrade on mainnet
 		{UpgradeName: V010217UpgradeName, CreateUpgradeHandler: NoOpHandler},
@@ -26,6 +27,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010407UpgradeName, CreateUpgradeHandler: V010407UpgradeHandler},
 		{UpgradeName: V010500UpgradeName, CreateUpgradeHandler: V010500UpgradeHandler},
 		{UpgradeName: V010501UpgradeName, CreateUpgradeHandler: V010501UpgradeHandler},
+		{UpgradeName: V010503UpgradeName, CreateUpgradeHandler: V010503UpgradeHandler},
 		{UpgradeName: V010600UpgradeName, CreateUpgradeHandler: V010600UpgradeHandler},
 	}
 }

--- a/app/upgrades/v1_5.go
+++ b/app/upgrades/v1_5.go
@@ -58,7 +58,7 @@ func V010503rc0UpgradeHandler(
 	appKeepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// update all withdrawal records' distributons to use new Amount field.
+		// update all withdrawal records' distributors to use new Amount field.
 		appKeepers.InterchainstakingKeeper.IterateWithdrawalRecords(ctx, func(index int64, record icstypes.WithdrawalRecord) (stop bool) {
 			if record.Distribution == nil {
 				// skip records that are queued.
@@ -121,7 +121,7 @@ func V010503UpgradeHandler(
 			return false
 		})
 
-		// update all withdrawal records' distributons to use new Amount field.
+		// update all withdrawal records' distributors to use new Amount field.
 		appKeepers.InterchainstakingKeeper.IterateWithdrawalRecords(ctx, func(index int64, record icstypes.WithdrawalRecord) (stop bool) {
 			if record.Distribution == nil {
 				// skip records that are queued.

--- a/app/upgrades/v1_5.go
+++ b/app/upgrades/v1_5.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/quicksilver-zone/quicksilver/app/keepers"
 	"github.com/quicksilver-zone/quicksilver/utils"
+	cmtypes "github.com/quicksilver-zone/quicksilver/x/claimsmanager/types"
 	icstypes "github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
 	prkeeper "github.com/quicksilver-zone/quicksilver/x/participationrewards/keeper"
 	prtypes "github.com/quicksilver-zone/quicksilver/x/participationrewards/types"
@@ -51,7 +52,116 @@ func V010500rc1UpgradeHandler(
 	}
 }
 
+func V010503rc0UpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	appKeepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// update all withdrawal records' distributons to use new Amount field.
+		appKeepers.InterchainstakingKeeper.IterateWithdrawalRecords(ctx, func(index int64, record icstypes.WithdrawalRecord) (stop bool) {
+			if record.Distribution == nil {
+				// skip records that are queued.
+				return false
+			}
+
+			newDist := make([]*icstypes.Distribution, 0, len(record.Distribution))
+			for _, d := range record.Distribution {
+				d.Amount = math.NewIntFromUint64(d.XAmount)
+				d.XAmount = 0
+				newDist = append(newDist, d)
+			}
+			record.Distribution = newDist
+			appKeepers.InterchainstakingKeeper.SetWithdrawalRecord(ctx, record)
+
+			return false
+		})
+
+		// for all claims, update to use new Amount field
+		appKeepers.ClaimsManagerKeeper.IterateAllClaims(ctx, func(index int64, key []byte, data cmtypes.Claim) (stop bool) {
+			data.Amount = math.NewIntFromUint64(data.XAmount)
+			appKeepers.ClaimsManagerKeeper.SetClaim(ctx, &data)
+			return false
+		})
+
+		appKeepers.ClaimsManagerKeeper.IterateAllLastEpochClaims(ctx, func(index int64, key []byte, data cmtypes.Claim) (stop bool) {
+			data.Amount = math.NewIntFromUint64(data.XAmount)
+			appKeepers.ClaimsManagerKeeper.SetClaim(ctx, &data)
+			return false
+		})
+
+		// for all redelegation records, migrate
+		appKeepers.InterchainstakingKeeper.IterateRedelegationRecords(ctx, func(index int64, key []byte, record icstypes.RedelegationRecord) (stop bool) {
+			record.Amount = math.NewInt(record.XAmount)
+			return false
+		})
+
+		appKeepers.InterchainstakingKeeper.SetConnectionForPort(ctx, "connection-4", "icacontroller-osmo-test-5.performance")
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
 // =========== PRODUCTION UPGRADE HANDLER ===========
+
+func V010503UpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	appKeepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// fix paid up juno records wher ack was never received.
+		appKeepers.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, "juno-1", 4, func(index int64, record icstypes.WithdrawalRecord) (stop bool) {
+			// burn burnAmount!
+			if err := appKeepers.BankKeeper.BurnCoins(ctx, icstypes.EscrowModuleAccount, sdk.NewCoins(record.BurnAmount)); err != nil {
+				// if we can't burn the coins, fail.
+				panic(err)
+			}
+			appKeepers.InterchainstakingKeeper.DeleteWithdrawalRecord(ctx, record.ChainId, record.Txhash, record.Status)
+			return false
+		})
+
+		// update all withdrawal records' distributons to use new Amount field.
+		appKeepers.InterchainstakingKeeper.IterateWithdrawalRecords(ctx, func(index int64, record icstypes.WithdrawalRecord) (stop bool) {
+			if record.Distribution == nil {
+				// skip records that are queued.
+				return false
+			}
+
+			newDist := make([]*icstypes.Distribution, 0, len(record.Distribution))
+			for _, d := range record.Distribution {
+				d.Amount = math.NewIntFromUint64(d.XAmount)
+				d.XAmount = 0
+				newDist = append(newDist, d)
+			}
+			record.Distribution = newDist
+			appKeepers.InterchainstakingKeeper.SetWithdrawalRecord(ctx, record)
+
+			return false
+		})
+
+		// for all claims, update to use new Amount field
+		appKeepers.ClaimsManagerKeeper.IterateAllClaims(ctx, func(index int64, key []byte, data cmtypes.Claim) (stop bool) {
+			data.Amount = math.NewIntFromUint64(data.XAmount)
+			appKeepers.ClaimsManagerKeeper.SetClaim(ctx, &data)
+			return false
+		})
+
+		appKeepers.ClaimsManagerKeeper.IterateAllLastEpochClaims(ctx, func(index int64, key []byte, data cmtypes.Claim) (stop bool) {
+			data.Amount = math.NewIntFromUint64(data.XAmount)
+			appKeepers.ClaimsManagerKeeper.SetLastEpochClaim(ctx, &data)
+			return false
+		})
+
+		// for all redelegation records, migrate
+		appKeepers.InterchainstakingKeeper.IterateRedelegationRecords(ctx, func(index int64, key []byte, record icstypes.RedelegationRecord) (stop bool) {
+			record.Amount = math.NewInt(record.XAmount)
+			return false
+		})
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
 
 func V010501UpgradeHandler(
 	mm *module.Manager,

--- a/app/upgrades/v1_5.go
+++ b/app/upgrades/v1_5.go
@@ -93,6 +93,7 @@ func V010503rc0UpgradeHandler(
 		// for all redelegation records, migrate
 		appKeepers.InterchainstakingKeeper.IterateRedelegationRecords(ctx, func(index int64, key []byte, record icstypes.RedelegationRecord) (stop bool) {
 			record.Amount = math.NewInt(record.XAmount)
+			appKeepers.InterchainstakingKeeper.SetRedelegationRecord(ctx, record)
 			return false
 		})
 
@@ -156,6 +157,7 @@ func V010503UpgradeHandler(
 		// for all redelegation records, migrate
 		appKeepers.InterchainstakingKeeper.IterateRedelegationRecords(ctx, func(index int64, key []byte, record icstypes.RedelegationRecord) (stop bool) {
 			record.Amount = math.NewInt(record.XAmount)
+			appKeepers.InterchainstakingKeeper.SetRedelegationRecord(ctx, record)
 			return false
 		})
 

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/quicksilver-zone/quicksilver/app/upgrades"
 	"github.com/quicksilver-zone/quicksilver/utils/addressutils"
+	cmtypes "github.com/quicksilver-zone/quicksilver/x/claimsmanager/types"
 	icstypes "github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
 	prtypes "github.com/quicksilver-zone/quicksilver/x/participationrewards/types"
 )
@@ -743,4 +744,70 @@ func (s *AppTestSuite) TestV010501UpgradeHandler() {
 	s.Equal("osmosis-1", lpd.ChainID)
 	s.Equal("cosmoshub-4", lpd.RegisteredZoneChainID)
 	s.Equal("uqatom", lpd.QAssetDenom)
+}
+
+func (s *AppTestSuite) TestV010503UpgradeHandler() {
+	s.InitV150TestZones()
+	app := s.GetQuicksilverApp(s.chainA)
+	ctx := s.chainA.GetContext()
+
+	user1 := addressutils.GenerateAddressForTestWithPrefix("quick")
+	recipient1 := addressutils.GenerateAddressForTestWithPrefix("cosmos")
+	val1 := addressutils.GenerateAddressForTestWithPrefix("cosmovaloper")
+	val2 := addressutils.GenerateAddressForTestWithPrefix("cosmovaloper")
+
+	wdr1 := icstypes.WithdrawalRecord{
+		ChainId:    s.chainB.ChainID,
+		BurnAmount: sdk.NewInt64Coin("uqatom", 300),
+		Distribution: []*icstypes.Distribution{
+			{Valoper: val1, XAmount: 110},
+			{Valoper: val2, XAmount: 220},
+		},
+		Amount:         sdk.NewCoins(sdk.NewInt64Coin("uatom", 330)),
+		Txhash:         fmt.Sprintf("%064d", 1),
+		Status:         icstypes.WithdrawStatusUnbond,
+		Delegator:      user1,
+		Recipient:      recipient1,
+		EpochNumber:    2,
+		CompletionTime: ctx.BlockTime().Add(3 * 24 * time.Hour),
+		Acknowledged:   true,
+	}
+
+	wdr2 := icstypes.WithdrawalRecord{
+		ChainId:      s.chainB.ChainID,
+		BurnAmount:   sdk.NewInt64Coin("uqatom", 300),
+		Distribution: nil,
+		Txhash:       fmt.Sprintf("%064d", 1),
+		Status:       icstypes.WithdrawStatusQueued,
+		Delegator:    user1,
+		Recipient:    recipient1,
+		EpochNumber:  2,
+	}
+
+	app.InterchainstakingKeeper.SetWithdrawalRecord(ctx, wdr1)
+	app.InterchainstakingKeeper.SetWithdrawalRecord(ctx, wdr2)
+
+	app.ClaimsManagerKeeper.SetClaim(ctx, &cmtypes.Claim{UserAddress: user1, ChainId: s.chainB.ChainID, Module: cmtypes.ClaimTypeLiquidToken, SourceChainId: "osmosis-1", XAmount: 3000})
+	app.ClaimsManagerKeeper.SetLastEpochClaim(ctx, &cmtypes.Claim{UserAddress: user1, ChainId: s.chainB.ChainID, Module: cmtypes.ClaimTypeLiquidToken, SourceChainId: "osmosis-1", XAmount: 2900})
+
+	handler := upgrades.V010503UpgradeHandler(app.mm,
+		app.configurator, &app.AppKeepers)
+
+	_, err := handler(ctx, types.Plan{}, app.mm.GetVersionMap())
+	s.NoError(err)
+
+	wdr2actual, found := app.InterchainstakingKeeper.GetWithdrawalRecord(ctx, wdr2.ChainId, wdr2.Txhash, wdr2.Status)
+	s.True(found)
+	s.Equal(wdr2actual, wdr2)
+
+	wdr1actual, found := app.InterchainstakingKeeper.GetWithdrawalRecord(ctx, wdr1.ChainId, wdr1.Txhash, wdr1.Status)
+	s.True(found)
+	s.Contains(wdr1actual.Distribution, &icstypes.Distribution{Valoper: val1, Amount: sdk.NewInt(110)})
+	s.Contains(wdr1actual.Distribution, &icstypes.Distribution{Valoper: val2, Amount: sdk.NewInt(220)})
+
+	claims := app.ClaimsManagerKeeper.AllZoneUserClaims(ctx, s.chainB.ChainID, user1)
+	s.Equal(claims[0].Amount, math.NewInt(3000))
+
+	leclaims := app.ClaimsManagerKeeper.AllZoneLastEpochUserClaims(ctx, s.chainB.ChainID, user1)
+	s.Equal(leclaims[0].Amount, math.NewInt(2900))
 }


### PR DESCRIPTION
## 1. Summary
Adds upgrade handlers for mainnet and testnet for v1.5.3.

```
Handler:
- Common:
  - Migrate all int64 token amounts to sdk.Math to avoid overflow.
- Mainnet only:
  - Tidy up juno completed unbondings that never received the final ack, and burn escrowed coins pertaining to the same.
- Testnet only:
  - Fix port mapping between connection-4 and icacontroller-osmo-test-5.performance that wasn't updated after re-registering osmo-test-5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced upgrade handlers for more efficient management of withdrawal records, claims, and redelegation records in interchain staking and claims.
	- Improved functionality to burn coins and delete withdrawal records in specific scenarios during upgrades.

- **Tests**
	- Validated upgrade handlers through comprehensive testing to ensure accurate updating and management of interchain staking and claims data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->