### PR TITLE
x/interchainstaking/keeper: comment about isNumericString choices

### DIFF
--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -1444,7 +1444,14 @@ func (*Keeper) prepareRewardsDistributionMsgs(zone types.Zone, rewards sdkmath.I
 }
 
 func isNumericString(in string) bool {
-	_, err := strconv.Atoi(in)
+	// It is okay to use strconv.ParseInt to test if a value is numeric
+	// because the total supply of QCK is:
+	//      400_000_000 (400 million) qck aka 400_000_000_000_000 uqck
+	// and to parse numeric values, say in the smallest unit of uqck
+	//      MaxInt64: (1<<63)-1 = 9_223_372_036_854_775_807 uqck aka
+	//                            9_223_372_036_854.775 (9.223 Trillion) qck
+        // so the function is appropriate as its range won't be exceeded.
+	_, err := strconv.ParseInt(in, 10, 64)
 	return err == nil
 }
 


### PR DESCRIPTION
Adds a comment for future selves, about the choice of strconv.ParseInt inside isNumericString and showing that its limits won't be exceeded.

Updates PR #1319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved numeric string validation in interchain staking logic to accommodate a wider range of token supplies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->