### PR TITLE
Base signalling intent off the most recent claims

### DIFF
--- a/x/interchainstaking/keeper/intent.go
+++ b/x/interchainstaking/keeper/intent.go
@@ -102,7 +102,7 @@ func (k *Keeper) AggregateDelegatorIntents(ctx sdk.Context, zone *types.Zone) er
 		balance := sdk.NewCoin(zone.LocalDenom, sdkmath.ZeroInt())
 		// grab offchain asset value, and raise the users' base value by this amount.
 		// currently ignoring base value (locally held assets)
-		k.ClaimsManagerKeeper.IterateLastEpochUserClaims(ctx, zone.ChainId, delIntent.Delegator, func(index int64, data prtypes.Claim) (stop bool) {
+		k.ClaimsManagerKeeper.IterateUserClaims(ctx, zone.ChainId, delIntent.Delegator, func(index int64, data prtypes.Claim) (stop bool) {
 			balance.Amount = balance.Amount.Add(data.Amount)
 			// claim amounts are in zone.baseDenom - but given weights are all relative to one another this okay.
 			k.Logger(ctx).Debug(

--- a/x/interchainstaking/types/expected_keepers.go
+++ b/x/interchainstaking/types/expected_keepers.go
@@ -47,6 +47,7 @@ type IcsHooks interface {
 
 type ClaimsManagerKeeper interface {
 	IterateLastEpochUserClaims(ctx sdk.Context, chainID, address string, fn func(index int64, data claimsmanagertypes.Claim) (stop bool))
+	IterateUserClaims(ctx sdk.Context, chainID, address string, fn func(index int64, data claimsmanagertypes.Claim) (stop bool))
 	SetClaim(ctx sdk.Context, claim *claimsmanagertypes.Claim)
 }
 


### PR DESCRIPTION
## 1. Summary
Fixes #1344

Use k.ClaimsManagerKeeper.IterateUserClaims instead of k.ClaimsManagerKeeper.IterateLastEpochUserClaims for AggregateIntent function.

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

