### PR TITLE
when flushing tokens, consider inflight unbondings (#996)

### DIFF
--- a/x/interchainstaking/keeper/delegation.go
+++ b/x/interchainstaking/keeper/delegation.go
@@ -324,6 +324,8 @@ func (k *Keeper) FlushOutstandingDelegations(ctx sdk.Context, zone *types.Zone, 
 		return false
 	})
 
+	pendingAmount = pendingAmount.Add(k.GetInflightUnbondingAmount(ctx, zone))
+
 	coinsToFlush, hasNeg := sdk.NewCoins(delAddrBalance).SafeSub(pendingAmount...)
 	if hasNeg || coinsToFlush.IsZero() {
 		k.Logger(ctx).Info("delegate account balance negative, or nothing to flush, setting outdated receipts")

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -515,6 +515,18 @@ func (k *Keeper) HandleMaturedUnbondings(ctx sdk.Context, zone *types.Zone) erro
 	return nil
 }
 
+func (k *Keeper) GetInflightUnbondingAmount(ctx sdk.Context, zone *types.Zone) sdk.Coin {
+	outCoin := sdk.NewCoin(zone.BaseDenom, sdk.ZeroInt())
+	k.IterateZoneWithdrawalRecords(ctx, zone.ChainId, func(idx int64, withdrawal types.WithdrawalRecord) bool {
+		if (withdrawal.Status == types.WithdrawStatusUnbond && ctx.BlockTime().After(withdrawal.CompletionTime) && withdrawal.Acknowledged) || // status unbond, completion has pass
+			withdrawal.Status == types.WithdrawStatusSend { // already in state send.
+			outCoin = outCoin.Add(withdrawal.Amount[0])
+		}
+		return false
+	})
+	return outCoin
+}
+
 func (k *Keeper) HandleTokenizedShares(ctx sdk.Context, msg sdk.Msg, sharesAmount sdk.Coin, memo string) error {
 	var err error
 	k.Logger(ctx).Info("received MsgTokenizeShares acknowledgement")


### PR DESCRIPTION
## 1. Summary
Fixes #1346

Re-add inadvertently removed logic that considers inflight unbondings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the staking system to include inflight unbonding amounts in the calculation of coins available for delegation, improving the accuracy of staking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->