### PR TITLE
use correct supply when determining proportions

### DIFF
--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -336,7 +336,7 @@ func (k *Keeper) HandleMsgTransfer(ctx sdk.Context, msg ibctransfertypes.Fungibl
 func (k *Keeper) DistributeToClaimants(ctx sdk.Context, zone *types.Zone, zoneAddress sdk.AccAddress, rewardsCoin sdk.Coin) (sdk.Coin, error) {
 	var err error
 	toDistribute := rewardsCoin.Amount
-	supply := k.BankKeeper.GetSupply(ctx, zone.BaseDenom).Amount
+	supply := k.BankKeeper.GetSupply(ctx, zone.LocalDenom).Amount
 	claimTotal := math.ZeroInt()
 	k.ClaimsManagerKeeper.IterateLastEpochClaims(ctx, zone.ChainId, func(index int64, data cmtypes.Claim) (stop bool) {
 		claimTotal = claimTotal.Add(data.Amount)


### PR DESCRIPTION
## 1. Summary
Fixes #1388 

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Use supply of zone.LocalDenom and not zone.BaseDenom to determine how to distribute rewards.