### PR TITLE
Use local channel in RTS logic

### DIFF
--- a/x/interchainstaking/keeper/receipt.go
+++ b/x/interchainstaking/keeper/receipt.go
@@ -141,8 +141,8 @@ func (k *Keeper) SendTokenIBC(ctx sdk.Context, senderAccAddress sdk.AccAddress, 
 
 	k.IBCKeeper.ChannelKeeper.IterateChannels(ctx, func(channel channeltypes.IdentifiedChannel) bool {
 		if channel.ConnectionHops[0] == zone.ConnectionId && channel.PortId == types.TransferPort && channel.State == channeltypes.OPEN {
-			srcChannel = channel.Counterparty.ChannelId
-			srcPort = channel.Counterparty.PortId
+			srcChannel = channel.ChannelId
+			srcPort = channel.PortId
 			return true
 		}
 		return false


### PR DESCRIPTION
## 1. Summary
Fixes #1497 

Change channel and port to use the local end of the connection, not the counterparty when sending for RTS.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the assignment of source channel and port identifiers to correctly reflect the current channel properties, enhancing accuracy in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->