### PR TITLE
2 byte memo is valid in case of rts

### DIFF
--- a/x/interchainstaking/types/zones.go
+++ b/x/interchainstaking/types/zones.go
@@ -240,7 +240,7 @@ func (z *Zone) validatorIntentsFromBytes(coins sdk.Coins, weightBytes []byte) (v
 }
 
 func ParseMemoFields(fieldBytes []byte) (MemoFields, error) {
-	if len(fieldBytes) < 3 {
+	if len(fieldBytes) < 2 {
 		return MemoFields{}, errors.New("invalid field bytes format")
 	}
 


### PR DESCRIPTION
## 1. Summary
Fixes error when sending a 2-byte memo, which is valid in the case of RTS (0x01 0x00)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the condition check in memo fields parsing to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->