### PR TITLE
ensure ibc migration is included in 1.6.0-beta0 handler

### DIFF
--- a/app/upgrades/v1_6.go
+++ b/app/upgrades/v1_6.go
@@ -6,7 +6,7 @@ import (
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	v6 "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/controller/migrations/v6"
+	v6migration "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/controller/migrations/v6"
 
 	"github.com/quicksilver-zone/quicksilver/app/keepers"
 	icstypes "github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
@@ -22,7 +22,7 @@ func V010600beta0UpgradeHandler(
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		if isTestnet(ctx) {
 			appKeepers.UpgradeKeeper.Logger(ctx).Info("migrating capabilities")
-			err := v6.MigrateICS27ChannelCapability(
+			err := v6migration.MigrateICS27ChannelCapability(
 				ctx,
 				appKeepers.IBCKeeper.Codec(),
 				appKeepers.GetKey(capabilitytypes.StoreKey),

--- a/app/upgrades/v1_6.go
+++ b/app/upgrades/v1_6.go
@@ -3,9 +3,13 @@ package upgrades
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	v6 "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/controller/migrations/v6"
+
 	"github.com/quicksilver-zone/quicksilver/app/keepers"
+	icstypes "github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
 )
 
 // ============ TESTNET UPGRADE HANDLERS ============
@@ -17,6 +21,19 @@ func V010600beta0UpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		if isTestnet(ctx) {
+			appKeepers.UpgradeKeeper.Logger(ctx).Info("migrating capabilities")
+			err := v6.MigrateICS27ChannelCapability(
+				ctx,
+				appKeepers.IBCKeeper.Codec(),
+				appKeepers.GetKey(capabilitytypes.StoreKey),
+				appKeepers.CapabilityKeeper,
+				icstypes.ModuleName,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			appKeepers.UpgradeKeeper.Logger(ctx).Info("removing defunct zones")
 			appKeepers.InterchainstakingKeeper.RemoveZoneAndAssociatedRecords(ctx, "agoric-3")
 			appKeepers.InterchainstakingKeeper.RemoveZoneAndAssociatedRecords(ctx, "archway-1")
 			appKeepers.InterchainQueryKeeper.SetLatestHeight(ctx, "provider", 6209948)


### PR DESCRIPTION
## 1. Summary
Fixes issue with v1.6.0-beta0 upgrade, where capabilities have not been migrated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated imports for `ibc-go/v6` and `quicksilver-zone/quicksilver`.
	- Introduced migration logic for capabilities and zone removal in the upgrade handler function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->