### PR TITLE
fix(icq-relayer/config): return immediately on non-os.IsNotExist errors

### DIFF
--- a/icq-relayer/cmd/config.go
+++ b/icq-relayer/cmd/config.go
@@ -24,11 +24,15 @@ func initConfig(cmd *cobra.Command) error {
 	cfgPath := path.Join(home, "config.yaml")
 	_, err = os.Stat(cfgPath)
 	if err != nil {
-		err = config.CreateConfig(home)
-		if err != nil {
+		if !os.IsNotExist(err) { // Return immediately
+			return err
+		}
+
+		if err := config.CreateConfig(home); err != nil {
 			return err
 		}
 	}
+
 	viper.SetConfigFile(cfgPath)
 	err = viper.ReadInConfig()
 	if err != nil {

--- a/icq-relayer/pkg/config/config.go
+++ b/icq-relayer/pkg/config/config.go
@@ -15,8 +15,17 @@ import (
 func CreateConfig(home string) error {
 	cfgPath := path.Join(home, "config.yaml")
 
-	// If the config doesn't exist...
-	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+	_, err := os.Stat(cfgPath)
+
+	switch {
+	case err == nil:
+		// Clear to go on.
+		break
+
+	case !os.IsNotExist(err):
+		return err
+
+	default: // The config does not exist, so create it.
 		// And the config folder doesn't exist...
 		// And the home folder doesn't exist
 		if _, err := os.Stat(home); os.IsNotExist(err) {
@@ -24,6 +33,8 @@ func CreateConfig(home string) error {
 			if err = os.Mkdir(home, os.ModePerm); err != nil {
 				return err
 			}
+		} else if err != nil { // All other errors should be returned immediately.
+			return err
 		}
 	}
 


### PR DESCRIPTION
This change avoids the need to try to brute-force creating an entirely fresh configuration, in the case where an error that isn't a path non-existence error occurs, for example in the case of a permission error on the parent directory or non-matching user/group permissions. Now we check against the returned error after os.Stat and accordingly return immediately or continue to create the configuration.

Fixes #1524