### PR TITLE
re-add claims cli tx 

### DIFF
--- a/x/participationrewards/client/cli/tx.go
+++ b/x/participationrewards/client/cli/tx.go
@@ -91,7 +91,6 @@ func GetSubmitClaimsTxCmd() *cobra.Command {
 			}
 
 			fileName := args[0]
-
 			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				return err


### PR DESCRIPTION
## 1. Summary
Adds CLI tx to submit multiple claims direct from the claims endpoint output.

## 2. Usage

```
curl -SsL https://claim.quicksilver.zone/<addr>/epoch | jq .messages | quicksilverd tx pr claims /dev/fd/0
```