### PR TITLE
Permit mapped accounts with 118 zones

### DIFF
--- a/x/interchainstaking/keeper/receipt.go
+++ b/x/interchainstaking/keeper/receipt.go
@@ -215,7 +215,7 @@ func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, sende
 		err = k.SendTokenIBC(ctx, k.AccountKeeper.GetModuleAddress(types.ModuleName), senderAddress, zone, qAssets[0])
 		k.Logger(ctx).Info("Transferred qAssets via rts", "address", senderAddress, "assets", qAssets)
 
-	case mappedAddress != nil && !zone.Is_118:
+	case mappedAddress != nil:
 		// set mapped account
 		if setMappedAddress {
 			k.SetAddressMapPair(ctx, sender, mappedAddress, zone.ChainId)


### PR DESCRIPTION
## 1. Summary
Fixes #1531

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Remove the conditional that checks the zone.Is_118 field prior to utilising a MappedAccount.