### PR TITLE
add upgrade handler for v1.6.0-beta1

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -26,6 +26,7 @@ const (
 	V010500rc1UpgradeName   = "v1.5.0-rc1"
 	V010503rc0UpgradeName   = "v1.5.3-rc0"
 	V010600beta0UpgradeName = "v1.6.0-beta0"
+	V010600beta1UpgradeName = "v1.6.0-beta1"
 	V010600rc0UpgradeName   = "v1.6.0-rc0"
 	V010600rc1UpgradeName   = "v1.6.0-rc1"
 

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -20,6 +20,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010500rc1UpgradeName, CreateUpgradeHandler: V010500rc1UpgradeHandler},
 		{UpgradeName: V010503rc0UpgradeName, CreateUpgradeHandler: V010503rc0UpgradeHandler},
 		{UpgradeName: V010600beta0UpgradeName, CreateUpgradeHandler: V010600beta0UpgradeHandler},
+		{UpgradeName: V010600beta1UpgradeName, CreateUpgradeHandler: V010600beta1UpgradeHandler},
 		{UpgradeName: V010600rc0UpgradeName, CreateUpgradeHandler: V010600rc0UpgradeHandler},
 
 		// v1.2: this needs to be present to support upgrade on mainnet

--- a/app/upgrades/v1_6.go
+++ b/app/upgrades/v1_6.go
@@ -14,6 +14,20 @@ import (
 
 // ============ TESTNET UPGRADE HANDLERS ============
 
+func V010600beta1UpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	appKeepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		if isTestnet(ctx) {
+			appKeepers.UpgradeKeeper.Logger(ctx).Info("removing defunct zones")
+			appKeepers.InterchainstakingKeeper.RemoveZoneAndAssociatedRecords(ctx, "elgafar-1")
+		}
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
 func V010600beta0UpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,


### PR DESCRIPTION
## 1. Summary
Adds upgrade handler for testnet deployment of v1.6.0-beta1

This removes the elgafar-1 zone which has an expired client.