### PR TITLE
test(x/interchainstaking/types): add a fuzzer for ParseMemoFields

### DIFF
--- a/x/interchainstaking/types/fuzz_test.go
+++ b/x/interchainstaking/types/fuzz_test.go
@@ -1,0 +1,49 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
+)
+
+func FuzzParseMemoFields(f *testing.F) {
+	if testing.Short() {
+		f.Skip("In -short mode")
+	}
+
+	// 1. Add the corpa seeds.
+	seeds := [][]byte{
+		// Valid sequences.
+		{
+			byte(types.FieldTypeAccountMap), 2, 1, 1,
+		},
+		{
+			byte(types.FieldTypeAccountMap), 2, 1, 1,
+			byte(types.FieldTypeReturnToSender), 0,
+		},
+
+		// Invalid sequences.
+		{
+			3, 2, 1, 1,
+			byte(types.FieldTypeReturnToSender), 0,
+		},
+		{
+			byte(types.FieldTypeAccountMap), 0,
+			byte(types.FieldTypeReturnToSender), 0,
+		},
+		{
+			byte(types.FieldTypeAccountMap), 3, 0, 0,
+			byte(types.FieldTypeReturnToSender), 4, 1, 1, 1, 3,
+		},
+		{byte(types.FieldTypeAccountMap), 1, 0, 0},
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	// 2. Now run the fuzzers.
+	f.Fuzz(func(t *testing.T, input []byte) {
+		_, _ = types.ParseMemoFields(input)
+	})
+}


### PR DESCRIPTION
This change adds a fuzzer for ParseMemoFields; this change is in anticipation of improving security and overall tests as we get ready to put up this repository on oss-fuzz for continuous fuzzing.