### PR TITLE
fix(x/interchainstaking/types): fuzz & fix DetermineAllocationsForUndelegation+DetermineAllocationsForUndelegationPredef

### DIFF
--- a/x/interchainstaking/types/delegation.go
+++ b/x/interchainstaking/types/delegation.go
@@ -125,12 +125,21 @@ func (vi ValidatorIntents) MustGetForValoper(valoper string) *ValidatorIntent {
 func (vi ValidatorIntents) Normalize() ValidatorIntents {
 	total := sdk.ZeroDec()
 	for _, i := range vi {
-		total = total.AddMut(i.Weight)
+		if !i.Weight.IsNil() {
+			total = total.AddMut(i.Weight)
+		}
 	}
 
 	out := make(ValidatorIntents, 0)
+
+	if total.IsZero() {
+		return out
+	}
+
 	for _, i := range vi {
-		out = append(out, &ValidatorIntent{ValoperAddress: i.ValoperAddress, Weight: i.Weight.Quo(total)})
+		if !i.Weight.IsNil() {
+			out = append(out, &ValidatorIntent{ValoperAddress: i.ValoperAddress, Weight: i.Weight.Quo(total)})
+		}
 	}
 	return out.Sort()
 }

--- a/x/interchainstaking/types/rebalance.go
+++ b/x/interchainstaking/types/rebalance.go
@@ -50,6 +50,9 @@ func CalculateAllocationDeltas(
 		if !ok {
 			target = &ValidatorIntent{ValoperAddress: valoper, Weight: sdk.ZeroDec()}
 		}
+		if target.Weight.IsNil() {
+			continue
+		}
 		targetAmount := target.Weight.MulInt(currentSum).TruncateInt()
 
 		// diff between target and current allocations

--- a/x/interchainstaking/types/redemptions_test.go
+++ b/x/interchainstaking/types/redemptions_test.go
@@ -10,41 +10,41 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/quicksilver-zone/quicksilver/utils/addressutils"
 	"github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
 )
 
-func TestDetermineAllocationsForUndelegation(t *testing.T) {
-	vals := addressutils.GenerateValidatorsDeterministic(4)
-	tests := []struct {
-		name               string
-		currentAllocations map[string]sdkmath.Int
-		unlocked           map[string]sdkmath.Int
-		targetAllocations  types.ValidatorIntents
-		amount             sdk.Coins
-		expected           map[string]sdkmath.Int
-	}{
+type detRedemptionTest struct {
+	Name               string                 `json:"name"`
+	CurrentAllocations map[string]sdkmath.Int `json:"cur_allocs"`
+	Unlocked           map[string]sdkmath.Int `json:"Unlocked"`
+	TargetAllocations  types.ValidatorIntents `json:"targ_allocs"`
+	Amount             sdk.Coins              `json:"amount"`
+	expected           map[string]sdkmath.Int
+}
+
+func detRedemptionTests(vals []string) []*detRedemptionTest {
+	return []*detRedemptionTest{
 		{
-			name: "case 0: equal delegations, equal intents; no locked",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 0: equal delegations, equal intents; no locked",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(1000),
 				vals[1]: sdk.NewInt(1000),
 				vals[2]: sdk.NewInt(1000),
 				vals[3]: sdk.NewInt(1000),
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(1000),
 				vals[1]: sdk.NewInt(1000),
 				vals[2]: sdk.NewInt(1000),
 				vals[3]: sdk.NewInt(1000),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(25, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
 			expected: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(250),
 				vals[1]: sdk.NewInt(250),
@@ -53,27 +53,27 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "case 1: unequal delegations, equal intents; no locked",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 1: unequal delegations, equal intents; no locked",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(1000), // + 25
 				vals[1]: sdk.NewInt(950),  // -25
 				vals[2]: sdk.NewInt(1200), // + 225
 				vals[3]: sdk.NewInt(750),  // -225
 				// 250; 0, -25, 0, -225; 225, 200, 225, 0; 650 (275, 225, 475, 25)
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(1000),
 				vals[1]: sdk.NewInt(950),
 				vals[2]: sdk.NewInt(1200),
 				vals[3]: sdk.NewInt(750),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(25, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
 			expected: map[string]sdkmath.Int{
 				// vals[0]: sdk.NewInt(275),
 				// vals[1]: sdk.NewInt(225),
@@ -86,26 +86,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "case 2: unequal delegations, unequal intents; no locked",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 2: unequal delegations, unequal intents; no locked",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(5000), // +500
 				vals[1]: sdk.NewInt(1800), // 0
 				vals[2]: sdk.NewInt(1200), // -150
 				vals[3]: sdk.NewInt(1000), // + 550
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(5000),
 				vals[1]: sdk.NewInt(1800),
 				vals[2]: sdk.NewInt(1200),
 				vals[3]: sdk.NewInt(1000),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(50, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(20, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(15, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(5, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(300))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(300))),
 			expected: map[string]sdkmath.Int{
 				vals[0]: sdk.NewInt(143),
 				vals[1]: sdk.NewInt(0), // 0
@@ -114,26 +114,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "case 3: unequal delegations, unequal intents, big discrepancy in intent (should not take from underallocated); no locked",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 3: unequal delegations, unequal intents, big discrepancy in intent (should not take from underallocated); no locked",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(1234), // 252  +982
 				vals[1]: sdkmath.NewInt(675),  // 504   +171
 				vals[2]: sdkmath.NewInt(210),  // 756   - 546
 				vals[3]: sdkmath.NewInt(401),  // 1008  - 607
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(1234),
 				vals[1]: sdkmath.NewInt(675),
 				vals[2]: sdkmath.NewInt(210),
 				vals[3]: sdkmath.NewInt(401),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(10, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(20, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(30, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(40, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100))),
 			expected: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(86),
 				vals[1]: sdkmath.NewInt(14),
@@ -142,26 +142,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "case 4: equal delegations, equal intents; vals[0] partially locked",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 4: equal delegations, equal intents; vals[0] partially locked",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(1000),
 				vals[1]: sdkmath.NewInt(1000),
 				vals[2]: sdkmath.NewInt(1000),
 				vals[3]: sdkmath.NewInt(1000),
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(500),
 				vals[1]: sdkmath.NewInt(1000),
 				vals[2]: sdkmath.NewInt(1000),
 				vals[3]: sdkmath.NewInt(1000),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(25, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
 			expected: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(250),
 				vals[1]: sdkmath.NewInt(250),
@@ -170,26 +170,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "case 5: equal delegations, equal intents; vals[0] partially locked #2",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 5: equal delegations, equal intents; vals[0] partially locked #2",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(1000),
 				vals[1]: sdkmath.NewInt(1000),
 				vals[2]: sdkmath.NewInt(1000),
 				vals[3]: sdkmath.NewInt(1000),
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(200),
 				vals[1]: sdkmath.NewInt(1000),
 				vals[2]: sdkmath.NewInt(1000),
 				vals[3]: sdkmath.NewInt(1000),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(25, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
 			expected: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(200),
 				vals[1]: sdkmath.NewInt(300),
@@ -198,26 +198,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "case 6: equal delegations, equal intents; vals[0] completely locked",
-			currentAllocations: map[string]sdkmath.Int{
+			Name: "case 6: equal delegations, equal intents; vals[0] completely locked",
+			CurrentAllocations: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(1000),
 				vals[1]: sdkmath.NewInt(1000),
 				vals[2]: sdkmath.NewInt(1000),
 				vals[3]: sdkmath.NewInt(1000),
 			},
-			unlocked: map[string]sdkmath.Int{
+			Unlocked: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(0),
 				vals[1]: sdkmath.NewInt(1000),
 				vals[2]: sdkmath.NewInt(1000),
 				vals[3]: sdkmath.NewInt(1000),
 			},
-			targetAllocations: types.ValidatorIntents{
+			TargetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: vals[0], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[1], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[2], Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: vals[3], Weight: sdk.NewDecWithPrec(25, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdkmath.NewInt(1000))),
+			Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdkmath.NewInt(1000))),
 			expected: map[string]sdkmath.Int{
 				vals[0]: sdkmath.NewInt(0),
 				vals[1]: sdkmath.NewInt(334),
@@ -226,21 +226,27 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			},
 		},
 	}
+}
+
+func sum(in map[string]sdkmath.Int) sdkmath.Int {
+	out := sdk.ZeroInt()
+	for _, i := range in {
+		out = out.Add(i)
+	}
+	return out
+}
+
+func TestDetermineAllocationsForUndelegation(t *testing.T) {
+	tests := detRedemptionTests(vals)
+
 	for _, tt := range tests {
-		sum := func(in map[string]sdkmath.Int) sdkmath.Int {
-			out := sdk.ZeroInt()
-			for _, i := range in {
-				out = out.Add(i)
-			}
-			return out
-		}
-		allocations, err := types.DetermineAllocationsForUndelegation(tt.currentAllocations, map[string]bool{}, sum(tt.currentAllocations), tt.targetAllocations, tt.unlocked, tt.amount)
+		allocations, err := types.DetermineAllocationsForUndelegation(tt.CurrentAllocations, map[string]bool{}, sum(tt.CurrentAllocations), tt.TargetAllocations, tt.Unlocked, tt.Amount)
 		require.NoError(t, err)
 		for valoper := range allocations {
-			require.Equal(t, tt.expected[valoper].Int64(), allocations[valoper].Int64(), fmt.Sprintf("%s / %s", tt.name, valoper))
+			require.Equal(t, tt.expected[valoper].Int64(), allocations[valoper].Int64(), fmt.Sprintf("%s / %s", tt.Name, valoper))
 		}
 		// validate that the amount withdrawn always matches total amount.
-		require.Equal(t, tt.amount[0].Amount, sum(allocations))
+		require.Equal(t, tt.Amount[0].Amount, sum(allocations))
 	}
 }
 
@@ -305,7 +311,7 @@ func TestOverAndUnderAllocatedValidators(t *testing.T) {
 // 		"validator4": sdkmath.NewInt(300),
 // 	}
 
-// 	allocations := types.DetermineAllocationsForUndelegation(currentAllocations, lockedAllocations, currentSum, targetAllocations, availablePerValidator, amount)
+// 	allocations := types.DetermineAllocationsForUndelegation(CurrentAllocations, lockedAllocations, currentSum, TargetAllocations, availablePerValidator, amount)
 
 // 	fmt.Println(allocations)
 // 	require.Equal(t, expectedAllocations, allocations)

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/0777dbc44ddc60cb
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/0777dbc44ddc60cb
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Cur_AlloCs\":{\"\":\"0\"},\"UnloCked\":{\"\":\"10\"},\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/0cfb38613ecdce31
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/0cfb38613ecdce31
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Amount\":[{}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/333ee1fc6512f2f6
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/333ee1fc6512f2f6
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"tArg_AlloCs\":[{}],\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/4f4936e9fba42620
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/4f4936e9fba42620
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"UnloCked\":{\"\":\"01\"},\"tArg_AlloCs\":[{}],\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/4f752dc378902922
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/4f752dc378902922
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Cur_AlloCs\":{\"\":\"0\"},\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/deb2c6c5eb30051c
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/deb2c6c5eb30051c
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Cur_AlloCs\":{\"\":\"1\"},\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/eda5d37a2e0c6535
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegation/eda5d37a2e0c6535
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"UnloCked\":{\"\":\"1\"},\"tArg_AlloCs\":[{\"weight\":\"0\"}],\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/0aee92286f0a9a14
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/0aee92286f0a9a14
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"tArg_AlloCs\":[{\"weight\":\"0\"}],\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/0cfb38613ecdce31
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/0cfb38613ecdce31
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Amount\":[{}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/333ee1fc6512f2f6
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/333ee1fc6512f2f6
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"tArg_AlloCs\":[{}],\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/deb2c6c5eb30051c
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/deb2c6c5eb30051c
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Cur_AlloCs\":{\"\":\"1\"},\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/eda5d37a2e0c6535
+++ b/x/interchainstaking/types/testdata/fuzz/FuzzDetermineAllocationsForUndelegationPredef/eda5d37a2e0c6535
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"UnloCked\":{\"\":\"1\"},\"tArg_AlloCs\":[{\"weight\":\"0\"}],\"Amount\":[{\"Amount\":\"1\"}]}")

--- a/x/interchainstaking/types/undelegation_fuzz_test.go
+++ b/x/interchainstaking/types/undelegation_fuzz_test.go
@@ -1,0 +1,64 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/quicksilver-zone/quicksilver/x/interchainstaking/types"
+)
+
+func FuzzDetermineAllocationsForUndelegation(f *testing.F) {
+	if testing.Short() {
+		f.Skip("Running in -short mode")
+	}
+
+	seeds := detRedemptionTests(vals)
+	for _, seed := range seeds {
+		blob, err := json.Marshal(seed)
+		if err == nil {
+			f.Add(blob)
+		}
+	}
+
+	f.Fuzz(func(_ *testing.T, inputJSON []byte) {
+		drt := new(detRedemptionTest)
+		if err := json.Unmarshal(inputJSON, drt); err != nil {
+			return
+		}
+		_, _ = types.DetermineAllocationsForUndelegation(
+			drt.CurrentAllocations,
+			map[string]bool{},
+			sum(drt.CurrentAllocations),
+			drt.TargetAllocations,
+			drt.Unlocked,
+			drt.Amount)
+	})
+}
+
+func FuzzDetermineAllocationsForUndelegationPredef(f *testing.F) {
+	if testing.Short() {
+		f.Skip("Running in -short mode")
+	}
+
+	seeds := detRedemptionTests(vals)
+	for _, seed := range seeds {
+		blob, err := json.Marshal(seed)
+		if err == nil {
+			f.Add(blob)
+		}
+	}
+
+	f.Fuzz(func(_ *testing.T, inputJSON []byte) {
+		drt := new(detRedemptionTest)
+		if err := json.Unmarshal(inputJSON, drt); err != nil {
+			return
+		}
+		_, _ = types.DetermineAllocationsForUndelegationPredef(
+			drt.CurrentAllocations,
+			map[string]bool{},
+			sum(drt.CurrentAllocations),
+			drt.TargetAllocations,
+			drt.Unlocked,
+			drt.Amount)
+	})
+}


### PR DESCRIPTION
This change introduces fuzzers for:
* DetermineAllocationsForUndelegation
* DetermineAllocationsForUndelegationPredef

as well as fixes for the identified non-defensive bugs that were
reported from ~2.2hr of fuzzing.

Fixes #1544
Fixes #1545
Fixes #1546