### PR TITLE
Remove potential non det

### DIFF
--- a/app/upgrades/v1_5.go
+++ b/app/upgrades/v1_5.go
@@ -533,7 +533,7 @@ func initialiseClaimsMetaData(ctx sdk.Context, appKeepers *keepers.AppKeepers) e
 		{
 			PoolID:   903,
 			PoolName: "qSTARS/STARS",
-			PoolData: []byte(`{"address":"osmo1cxlrfu8r0v3cyqj78fuvlsmhjdgna0r7tum8cpd0g3x7w7pte8fsfvcs84","id":903,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"24h","total_shares":{"denom":"gamm/pool/903","amount":"36839899550979704528582"},"pool_liquidity":[{"denom":"ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83","amount":"238430845376"},{"denom":"ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4","amount":"721246955212"}],"scaling_factors":["1","1"],"scaling_factor_controller":""}`),
+			PoolData: []byte(`{"address":"osmo1cxlrfu8r0v3cyqj78fuvlsmhjdgna0r7tum8cpd0g3x7w7pte8fsfvcs84","id":903,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"24h","total_shares":{"denom":"gamm/pool/903","amount":"36839899550979704528582"},"pool_liquidity":[{"denom":"ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83","amount":"238430845376"},{"denom":"ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4","amount":"721246955212"}],"scaling_factors":[1,1],"scaling_factor_controller":""}`),
 			PoolType: prtypes.PoolTypeStableSwap,
 			Denoms: map[string]prtypes.DenomWithZone{
 				"ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83": {Denom: "uqstars", ChainID: "stargaze-1"},
@@ -544,7 +544,7 @@ func initialiseClaimsMetaData(ctx sdk.Context, appKeepers *keepers.AppKeepers) e
 		{
 			PoolID:   944,
 			PoolName: "ATOM/qATOM",
-			PoolData: []byte(`{"address":"osmo1awr39mc2hrkt8gq8gt3882ru40ay45k8a3yg69nyypqe9g0ryycs66lhkh","id":944,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/944","amount":"6108537302303463956540"},"pool_liquidity":[{"denom":"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2","amount":"42678069500"},{"denom":"ibc/FA602364BEC305A696CBDF987058E99D8B479F0318E47314C49173E8838C5BAC","amount":"70488173547"}],"scaling_factors":["1202853876","1000000000"],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
+			PoolData: []byte(`{"address":"osmo1awr39mc2hrkt8gq8gt3882ru40ay45k8a3yg69nyypqe9g0ryycs66lhkh","id":944,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/944","amount":"6108537302303463956540"},"pool_liquidity":[{"denom":"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2","amount":"42678069500"},{"denom":"ibc/FA602364BEC305A696CBDF987058E99D8B479F0318E47314C49173E8838C5BAC","amount":"70488173547"}],"scaling_factors":[1202853876,1000000000],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
 			PoolType: prtypes.PoolTypeStableSwap,
 			Denoms: map[string]prtypes.DenomWithZone{
 				"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2": {Denom: "uatom", ChainID: "cosmoshub-4"},
@@ -555,7 +555,7 @@ func initialiseClaimsMetaData(ctx sdk.Context, appKeepers *keepers.AppKeepers) e
 		{
 			PoolID:   948,
 			PoolName: "REGEN/qREGEN",
-			PoolData: []byte(`{"address":"osmo1hylqy4uu5el36wykhzzhj786eh8rx4epyvg6nrtl503wjufz8z3sdptdzw","id":948,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/948","amount":"205748905065147865419005"},"pool_liquidity":[{"denom":"ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076","amount":"258144972321"},{"denom":"ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206","amount":"171893185502"}],"scaling_factors":["1264169382","1000000000"],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
+			PoolData: []byte(`{"address":"osmo1hylqy4uu5el36wykhzzhj786eh8rx4epyvg6nrtl503wjufz8z3sdptdzw","id":948,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/948","amount":"205748905065147865419005"},"pool_liquidity":[{"denom":"ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076","amount":"258144972321"},{"denom":"ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206","amount":"171893185502"}],"scaling_factors":[1264169382,1000000000],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
 			PoolType: prtypes.PoolTypeStableSwap,
 			Denoms: map[string]prtypes.DenomWithZone{
 				"ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076": {Denom: "uregen", ChainID: "regen-1"},
@@ -566,7 +566,7 @@ func initialiseClaimsMetaData(ctx sdk.Context, appKeepers *keepers.AppKeepers) e
 		{
 			PoolID:   956,
 			PoolName: "qOSMO/OSMO",
-			PoolData: []byte(`{"address":"osmo1q023e9m4d3ffvr96xwaeraa62yfvufkufkr7yf7lmacgkuspsuqsga4xp2","id":956,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/956","amount":"2443712227421775628369"},"pool_liquidity":[{"denom":"ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC","amount":"5378958960"},{"denom":"uosmo","amount":"4563791740"}],"scaling_factors":["1000000000","1141529049"],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
+			PoolData: []byte(`{"address":"osmo1q023e9m4d3ffvr96xwaeraa62yfvufkufkr7yf7lmacgkuspsuqsga4xp2","id":956,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/956","amount":"2443712227421775628369"},"pool_liquidity":[{"denom":"ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC","amount":"5378958960"},{"denom":"uosmo","amount":"4563791740"}],"scaling_factors":[1000000000,1141529049],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
 			PoolType: prtypes.PoolTypeStableSwap,
 			Denoms: map[string]prtypes.DenomWithZone{
 				"ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC": {Denom: "uqosmo", ChainID: "osmosis-1"},
@@ -577,7 +577,7 @@ func initialiseClaimsMetaData(ctx sdk.Context, appKeepers *keepers.AppKeepers) e
 		{
 			PoolID:   1087,
 			PoolName: "SOMM/qSOMM",
-			PoolData: []byte(`{"address":"osmo1unwajz776rcsvaaehrq82qldwfw4zeqp7jgty09cw4lytuwfw3pqvs0cmt","id":1087,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/1087","amount":"2103498772356422991482414"},"pool_liquidity":[{"denom":"ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E","amount":"150351552009"},{"denom":"ibc/EAF76AD1EEF7B16D167D87711FB26ABE881AC7D9F7E6D0CF313D5FA530417208","amount":"273114101299"}],"scaling_factors":["1032934412","1000000000"],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
+			PoolData: []byte(`{"address":"osmo1unwajz776rcsvaaehrq82qldwfw4zeqp7jgty09cw4lytuwfw3pqvs0cmt","id":1087,"pool_params":{"swap_fee":"0.003000000000000000","exit_fee":"0.000000000000000000"},"future_pool_governor":"168h","total_shares":{"denom":"gamm/pool/1087","amount":"2103498772356422991482414"},"pool_liquidity":[{"denom":"ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E","amount":"150351552009"},{"denom":"ibc/EAF76AD1EEF7B16D167D87711FB26ABE881AC7D9F7E6D0CF313D5FA530417208","amount":"273114101299"}],"scaling_factors":[1032934412,1000000000],"scaling_factor_controller":"osmo16x03wcp37kx5e8ehckjxvwcgk9j0cqnhm8m3yy"}`),
 			PoolType: prtypes.PoolTypeStableSwap,
 			Denoms: map[string]prtypes.DenomWithZone{
 				"ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E": {Denom: "usomm", ChainID: "sommelier-3"},

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -726,14 +726,14 @@ func (s *AppTestSuite) TestV010500UpgradeHandler() {
 	s.NoError(err)
 	expectedTvs := map[string]sdk.Dec{ // relative prices between assets as of 2024-03-09T11:00
 		"uosmo":  sdk.MustNewDecFromStr("1.000000000000000000"),
-		"uatom":  sdk.MustNewDecFromStr("8.312793554467208113"),
+		"uatom":  sdk.MustNewDecFromStr("8.312793554467208145"),
 		"ustars": sdk.MustNewDecFromStr("0.024508540336823926"),
 		"uregen": sdk.MustNewDecFromStr("0.034894445954581256"),
 		"usomm":  sdk.MustNewDecFromStr("0.108532538179923692"),
 		"ujuno":  sdk.MustNewDecFromStr("0.256801530018076838"),
 	}
-	for denom, value := range tvs {
-		s.Equal(expectedTvs[denom], value)
+	for denom, value := range expectedTvs {
+		s.Equal(tvs[denom], value)
 	}
 }
 

--- a/x/participationrewards/keeper/distribution.go
+++ b/x/participationrewards/keeper/distribution.go
@@ -154,12 +154,13 @@ func (k *Keeper) CalcTokenValues(ctx sdk.Context) (TokenValues, error) {
 		return false
 	})
 
-	for denom0, v := range graph {
+	for _, denom0 := range utils.Keys(graph) {
 		graph2[denom0] = make(map[string]sdk.Dec)
-		for denom1, weightedAssets := range v {
+		values := graph[denom0]
+		for _, denom1 := range utils.Keys(values) {
 			value := sdk.ZeroDec()
 			count := math.ZeroInt()
-			for _, asset := range weightedAssets {
+			for _, asset := range values[denom1] {
 				value = value.Add(asset)
 				count = count.Add(math.OneInt())
 			}

--- a/x/participationrewards/keeper/distribution.go
+++ b/x/participationrewards/keeper/distribution.go
@@ -27,9 +27,9 @@ func DepthFirstSearch(graph AssetGraph, visited map[string]struct{}, asset strin
 	visited[asset] = struct{}{}
 	result[asset] = price
 
-	for neighbour, neighbourPrice := range graph[asset] {
+	for _, neighbour := range utils.Keys(graph[asset]) {
 		if _, ok := visited[neighbour]; !ok {
-			DepthFirstSearch(graph, visited, neighbour, neighbourPrice.Mul(price), result)
+			DepthFirstSearch(graph, visited, neighbour, graph[asset][neighbour].Mul(price), result)
 		}
 	}
 }


### PR DESCRIPTION
## 1. Summary
- Fixes potential non determinism introduced by #1592 
- Fixes test failures in historic upgrade based on slight (intended) behaviour change (specifically, calculateTvs returns all token values, not just those pertaining to qAssets).