### PR TITLE
fix CL pool valid key length check

### DIFF
--- a/x/participationrewards/keeper/callbacks.go
+++ b/x/participationrewards/keeper/callbacks.go
@@ -171,8 +171,8 @@ func OsmosisClPoolUpdateCallback(ctx sdk.Context, k *Keeper, response []byte, qu
 		return err
 	}
 
-	// check query.Request is at least 9 bytes in length. (0x02 + 8 bytes for uint64)
-	if len(query.Request) < 5 {
+	// check query.Request is at least 2 bytes - 0x03 + poolID
+	if len(query.Request) < 2 {
 		return errors.New("query request not sufficient length")
 	}
 	// assert first character is 0x03 as expected (cl pool prefix)


### PR DESCRIPTION
## 1. Summary
Fixes issue in checking CL pool key validity in updateosmosisclpool callback.

CL pool keys are formed by prefix + []byte(pool_id.(string))

vs.

Gamm pool keys which are prefix + encode(uint64)

Gamm pool keys are always 9 bytes in length
CL pool keys are 2 bytes for pools 1-9, 3 bytes for pools 10-99, etc.

Key length check should reflect this.