### PR TITLE
return valid json for default genesis; fixes #1666

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -306,6 +306,10 @@ func (app *Quicksilver) AppCodec() codec.Codec {
 	return app.appCodec
 }
 
+func (app *Quicksilver) GetModuleManager() *module.Manager {
+	return app.mm
+}
+
 // InterfaceRegistry returns Quicksilver's InterfaceRegistry.
 func (app *Quicksilver) InterfaceRegistry() types.InterfaceRegistry {
 	return app.interfaceRegistry

--- a/x/interchainquery/genesis_test.go
+++ b/x/interchainquery/genesis_test.go
@@ -81,6 +81,11 @@ func (s *InterChainQueryTestSuite) TestInitGenesis() {
 	s.Equal("", queryResponse.CallbackId)
 }
 
+func (s *InterChainQueryTestSuite) TestInitGenesisDefault() {
+	app := s.GetSimApp(s.chainA)
+	app.GetModuleManager().Modules[types.ModuleName].InitGenesis(s.chainA.GetContext(), app.AppCodec(), app.GetModuleManager().Modules[types.ModuleName].DefaultGenesis(app.AppCodec()))
+}
+
 func newSimAppPath(chainA, chainB *ibctesting.TestChain) *ibctesting.Path {
 	path := ibctesting.NewPath(chainA, chainB)
 	path.EndpointA.ChannelConfig.PortID = ibctesting.TransferPort

--- a/x/interchainquery/module.go
+++ b/x/interchainquery/module.go
@@ -57,8 +57,8 @@ func (AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 }
 
 // DefaultGenesis returns the capability module's default genesis state.
-func (AppModuleBasic) DefaultGenesis(_ codec.JSONCodec) json.RawMessage {
-	return nil
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	return cdc.MustMarshalJSON(&types.GenesisState{})
 }
 
 // ValidateGenesis performs genesis state validation for the capability module.


### PR DESCRIPTION
## 1. Summary
Fixes #1666 

Return a correctly marshalled default genesis (even if it is empty), instead of nil, to avoid panic on chains adding ICQ.

Add test to validate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `GetModuleManager()` method to enhance module management capabilities.

- **Tests**
  - Added a new test `TestInitGenesisDefault` to ensure proper initialization of genesis state with default values.

- **Refactor**
  - Modified `DefaultGenesis` function to return JSON representation of `types.GenesisState` using a provided codec, improving consistency and flexibility in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->