### PR TITLE
fix: fix some broken links in CONTRIBUTING.md and PAID_BOUNTIES.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ And if you like the project, but just don't have time to contribute, that's fine
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Quicksilver Protocol Code of Conduct](blob/main/CODE_OF_CONDUCT.md).
+[Quicksilver Protocol Code of Conduct](./CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to .
 

--- a/PAID_BOUNTIES.md
+++ b/PAID_BOUNTIES.md
@@ -22,11 +22,11 @@ The evaluation of a change is the sole discretion of the Quicksilver maintainers
 ## Getting started
 
 Please use these steps as a guide to get you started:
-- [ ] Read through [CONTRIBUTING.md](./blob/main/CONTRIBUTING.md)
-- [ ] Read and understand our [CODE OF CONDUCT](./blob/main/CODE_OF_CONDUCT.md)
+- [ ] Read through [CONTRIBUTING.md](./CONTRIBUTING.md)
+- [ ] Read and understand our [CODE OF CONDUCT](./CODE_OF_CONDUCT.md)
 - [ ] Accept our Contributor License Agreement and agree to bring in only original changes that you have the correct rights to, please do not bring in contributions that contravene our license nor intellectual property not owned by you
-- [ ] Read through [ROADMAP.md](./blob/main/ROADMAP.md)
-- [ ] Read through the [Google Go style guide](https://google.github.io/styleguide/go/guide/)
+- [ ] Read through [ROADMAP.md](./ROADMAP.md)
+- [ ] Read through the [Google Go style guide](https://google.github.io/styleguide/go/guide)
 - [ ] Read through the open issues
 - [ ] Watch out for issues & pull requests that may be labelled "Eligible for Bounty"
 - [ ] Read through open pull requests


### PR DESCRIPTION
Majority of the links should not be prepended with "blob/main" because that inteferres with Github UI's root rendering which already prepends the branch name so without this fix it would produce failing links like

    https://github.com/quicksilver-zone/quicksilver/blob/main/blob/main/CODE_OF_CONDUCT.md

yet it should be

    https://github.com/quicksilver-zone/quicksilver/blob/main/CODE_OF_CONDUCT.md

Updates #1645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated link paths in `CONTRIBUTING.md` and `PAID_BOUNTIES.md` for better navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->