### PR TITLE
fix: do not throw error on race condition

### DIFF
--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -686,26 +686,7 @@ func (k *Keeper) HandleBeginRedelegate(ctx sdk.Context, msg sdk.Msg, completion 
 		0,
 	)
 
-	srcDelegation, found := k.GetDelegation(ctx, zone.ChainId, redelegateMsg.DelegatorAddress, redelegateMsg.ValidatorSrcAddress)
-	if !found {
-		k.Logger(ctx).Error("unable to find delegation record", "chain", zone.ChainId, "source", redelegateMsg.ValidatorSrcAddress, "dst", redelegateMsg.ValidatorDstAddress, "epoch_number", epochNumber)
-		// due to a race condition between IBC and ICQ, this might be nil.
-		return nil
-	}
-	srcDelegation.Amount, err = srcDelegation.Amount.SafeSub(redelegateMsg.Amount)
-	if err != nil {
-		if strings.Contains(err.Error(), "negative coin amount") {
-			// we received a negative srcDelegation. Obviously this cannot happen, but we can get a crossed re/un/delegation, all which fetch absolute values.
-			k.Logger(ctx).Error("possible race condition; unable to sub redelegation amount. requerying delegation anyway")
-		} else {
-			// we got some other, unrecoverable err
-			return err
-		}
-	} else {
-		k.SetDelegation(ctx, zone.ChainId, srcDelegation)
-	}
-
-	valAddr, err = addressutils.ValAddressFromBech32(redelegateMsg.ValidatorDstAddress, zone.AccountPrefix+"valoper")
+	valAddr, err = addressutils.ValAddressFromBech32(redelegateMsg.ValidatorSrcAddress, zone.AccountPrefix+"valoper")
 	if err != nil {
 		return err
 	}
@@ -723,6 +704,25 @@ func (k *Keeper) HandleBeginRedelegate(ctx sdk.Context, msg sdk.Msg, completion 
 		"delegation",
 		0,
 	)
+
+	srcDelegation, found := k.GetDelegation(ctx, zone.ChainId, redelegateMsg.DelegatorAddress, redelegateMsg.ValidatorSrcAddress)
+	if !found {
+		k.Logger(ctx).Error("unable to find delegation record", "chain", zone.ChainId, "source", redelegateMsg.ValidatorSrcAddress, "dst", redelegateMsg.ValidatorDstAddress, "epoch_number", epochNumber)
+		return nil
+	}
+	srcDelegation.Amount, err = srcDelegation.Amount.SafeSub(redelegateMsg.Amount)
+	if err != nil {
+		if strings.Contains(err.Error(), "negative coin amount") {
+			// we received a negative srcDelegation. Obviously this cannot happen, but we can get a crossed re/un/delegation, all which fetch absolute values.
+			k.Logger(ctx).Error("possible race condition; unable to sub redelegation amount. requerying delegation anyway")
+		} else {
+			// we got some other, unrecoverable err
+			return err
+		}
+	} else {
+		k.SetDelegation(ctx, zone.ChainId, srcDelegation)
+	}
+
 	return nil
 }
 

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -689,7 +689,8 @@ func (k *Keeper) HandleBeginRedelegate(ctx sdk.Context, msg sdk.Msg, completion 
 	srcDelegation, found := k.GetDelegation(ctx, zone.ChainId, redelegateMsg.DelegatorAddress, redelegateMsg.ValidatorSrcAddress)
 	if !found {
 		k.Logger(ctx).Error("unable to find delegation record", "chain", zone.ChainId, "source", redelegateMsg.ValidatorSrcAddress, "dst", redelegateMsg.ValidatorDstAddress, "epoch_number", epochNumber)
-		return fmt.Errorf("unable to find delegation record for chain %s, src: %s, dst: %s, at epoch %d", zone.ChainId, redelegateMsg.ValidatorSrcAddress, redelegateMsg.ValidatorDstAddress, epochNumber)
+		// due to a race condition between IBC and ICQ, this might be nil.
+		return nil
 	}
 	srcDelegation.Amount, err = srcDelegation.Amount.SafeSub(redelegateMsg.Amount)
 	if err != nil {


### PR DESCRIPTION
## 1. Summary
Fixes #1693 

Return nil instead of an error if we cannot find the delegation record, due to a race condition where ICA Ack were delayed.

Additionally, ensure that both src and dst delegations are queried regardless of being able to update delegation record, so we ensure we have the most current data possible.

## 2.Type of change

- [x] Bug fix - consensus breaking

## 3. Implementation details

When we handle ICA Acknowledgement for a MsgBeginRedelegate, which is subsequently delayed, an ICQ message may have deleted the corresponding Delegation record in the mean time. As such, when the Acknowledgement is processed, it looks for the record in an attempt to reduce it's value. We should not fail when this record cannot be found.