### PR TITLE
test(x/interchainquery): directly assert AppModuleBasic.DefaultGenesis return non-nil JSON

### DIFF
--- a/x/interchainquery/genesis_test.go
+++ b/x/interchainquery/genesis_test.go
@@ -93,3 +93,13 @@ func newSimAppPath(chainA, chainB *ibctesting.TestChain) *ibctesting.Path {
 
 	return path
 }
+
+// Assert to ensure that there is no panic on directly invoking .DefaultGenesis on AppModuleBasic
+// as previously reported in https://github.com/quicksilver-zone/quicksilver/issues/1666
+func (s *InterChainQueryTestSuite) TestAssertAppModuleBasicMarshalNonNilJSON() {
+	app := s.GetSimApp(s.chainA)
+	mod := new(interchainquery.AppModuleBasic)
+	blob := mod.DefaultGenesis(app.AppCodec())
+	s.True(blob != nil, "the JSON cannot be nil")
+	s.True(len(blob) > 1, "the length must be non-empty")
+}


### PR DESCRIPTION
This change tightens the test by directly unit testing that AppModuleBasic.DefaultGenesis returns a non-nil result. The test in #1666 is an outward API invocation but with the layers of indirection above, this code down below could change without notice, preventing effective testing and making for code rot.

Updates issue #1666
Updates PR #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new test to validate the behavior of the `DefaultGenesis` method, ensuring it returns a valid JSON blob and does not cause a panic.

- **Bug Fixes**
	- Addressed a previously reported issue by validating the output of the `DefaultGenesis` method, enhancing the robustness of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->