### PR TITLE
ensure we use the correct zone denom where evaluating pool claims

### DIFF
--- a/x/airdrop/keeper/claim_handler.go
+++ b/x/airdrop/keeper/claim_handler.go
@@ -307,7 +307,7 @@ func (k *Keeper) verifyOsmosisLP(ctx sdk.Context, proofs []*cmtypes.Proof, cr ty
 }
 
 func (k *Keeper) verifyPoolAndGetAmount(ctx sdk.Context, lock osmosislockuptypes.PeriodLock, cr types.ClaimRecord) (sdkmath.Int, error) {
-	return osmosistypes.DetermineApplicableTokensInPool(ctx, k.prKeeper, lock, cr.ChainId)
+	return osmosistypes.DetermineApplicableTokensInPool(ctx, k.prKeeper, lock, cr.ChainId, "UNUSED")
 }
 
 // -----------

--- a/x/participationrewards/keeper/submodule_osmosis.go
+++ b/x/participationrewards/keeper/submodule_osmosis.go
@@ -139,7 +139,13 @@ func (*OsmosisModule) ValidateClaim(ctx sdk.Context, k *Keeper, msg *types.MsgSu
 				}
 			}
 		}
-		sdkAmount, err := osmosistypes.DetermineApplicableTokensInPool(ctx, k, lock, msg.Zone)
+
+		denom, found := k.ApplicableDenomForZone(ctx, msg.Zone)
+		if !found {
+			return math.ZeroInt(), errors.New("no applicable denom found for zone")
+		}
+
+		sdkAmount, err := osmosistypes.DetermineApplicableTokensInPool(ctx, k, lock, msg.Zone, denom)
 		if err != nil {
 			return sdk.ZeroInt(), err
 		}


### PR DESCRIPTION
## 1. Summary

Osmosis Pools (legacy + CL) attempt to validate the denom for a claim against the zone, by checking the chain_id of the denom vs the chain_id of the zone. Given that the chain_id of a qAsset/asset pool will be the same for both denoms, the denom selected will be based on the order of the denoms in the slice - and not always validate the correct denom.

This change ensures we use the correct denom as listed for that qAsset on osmosis by the ProtocolDataAllowedLiquidToken.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Instead of checking whether denom X has chain_id Y (to match the zone), we lookup the local_denom of the zone, cross reference against the ProtocolDataAllowedLiquidToken list for osmosis (via the OsmosisParams PD chain_id), to ascertain whether we match on the denom. This is always guaranteed to yield the correct answer.

This introduces a contract that all claimable assets in a pool _MUST_ exist in the ProtocolDataAllowedLiquidToken list - however, I cannot foresee any instance where this isn't desirable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve applicable denominations for specific zones, enhancing claim validation.
	- Updated functions to accept additional parameters for improved token determination based on pool denominations.

- **Bug Fixes**
	- Improved error handling in token validation processes to enhance clarity and robustness.

- **Refactor**
	- Streamlined logic in existing functions to remove redundancy and simplify processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->