### PR TITLE
fix: stylecheck lint error on `chainId` in osmosis submodule

### DIFF
--- a/x/participationrewards/keeper/submodule_osmosiscl.go
+++ b/x/participationrewards/keeper/submodule_osmosiscl.go
@@ -132,8 +132,8 @@ func (*OsmosisClModule) KeyPool(poolID uint64) []byte {
 	return osmocl.KeyPool(poolID)
 }
 
-func (k *Keeper) ApplicableDenomForZone(ctx sdk.Context, chainId string) (denom string, found bool) {
-	zone, found := k.icsKeeper.GetZone(ctx, chainId)
+func (k *Keeper) ApplicableDenomForZone(ctx sdk.Context, chainID string) (denom string, found bool) {
+	zone, found := k.icsKeeper.GetZone(ctx, chainID)
 	if !found {
 		return "", false
 	}


### PR DESCRIPTION
## 1. Summary
Fixes # (issue)
<!-- What are you changing, removing, or adding in this review? -->
- fixes the lint error due to stylecheck linter on `chainId` variable.

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details
-  updated `chainId` to `chainID`
<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 4. How to test/use
<!-- How can people test/use this? -->
- run `golangci-lint@v1.58.0 run`
## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?
- NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in the `Hooks` method with clearer error messages for JSON unmarshalling and protocol data queries.

- **Improvements**
	- Updated parameter naming for clarity in the `ApplicableDenomForZone` method.
	- Clarified error messages in the `ValidateClaim` method for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->