### PR TITLE
fix nil reference panic in abci.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -358,3 +358,7 @@ replace (
 	github.com/tendermint/tendermint => github.com/cometbft/cometbft v0.34.33
 	github.com/tendermint/tm-db => github.com/notional-labs/tm-db v0.11.0
 )
+
+retract (
+	v1.7.0 // safety bug
+)


### PR DESCRIPTION
## 1. Summary
Fixes #1744 

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

Fix panic in v1.7.0 when onboarding a new zone.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a retraction for version `v1.7.0` due to a safety bug, ensuring users are aware of potential issues.
  
- **Bug Fixes**
	- Enhanced error handling in the interchain staking module to prevent runtime errors related to `zone.DelegationAddress`.

- **Chores**
	- Updated dependencies for improved compatibility and security, including adjustments for vulnerabilities in specific libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->