### PR TITLE
move prod upgrade handler to v1.7.2; remove additional stargaze txs

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -50,6 +50,7 @@ const (
 	V010604UpgradeName = "v1.6.4"
 
 	V010700UpgradeName = "v1.7.0"
+	V010702UpgradeName = "v1.7.2"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -25,6 +25,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010603UpgradeName, CreateUpgradeHandler: V010603UpgradeHandler},
 		{UpgradeName: V010604UpgradeName, CreateUpgradeHandler: V010604UpgradeHandler},
 		{UpgradeName: V010700UpgradeName, CreateUpgradeHandler: V010700UpgradeHandler},
+		{UpgradeName: V010702UpgradeName, CreateUpgradeHandler: V010702UpgradeHandler},
 	}
 }
 


### PR DESCRIPTION
## 1. Summary

- Update production upgrade handler from v1.7.0 to v1.7.2.
- Remove two additional withdrawals, and burn escrowed amount


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new upgrade version `v1.7.2` with its corresponding upgrade handler.
	- Added functionality for handling migrations and managing withdrawal records in specific environments.
	- Enhanced coin management capabilities, including minting and burning operations.

- **Bug Fixes**
	- Improved handling of duplicate withdrawal records for specific zones.

- **Documentation**
	- Updated upgrade constants and handlers to reflect the new versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->