### PR TITLE
fix git describe commands to fetch versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COSMOS_BUILD_OPTIONS ?= ""
 PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
 PACKAGES_SIM=github.com/quicksilver-zone/quicksilver/test/simulation
 PACKAGES_E2E=$(shell go list ./... | grep '/e2e')
-VERSION=$(shell git describe --tags | head -n1 | sed 's/.*\///')
+VERSION=$(shell git describe --tags --exclude "icq-relayer/*" --exclude "fe/*" --match "v*" | head -n1 | sed 's/.*\///')
 DOCKER_VERSION ?= $(VERSION)
 TMVERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')
 COMMIT := $(shell git log -1 --format='%H')

--- a/icq-relayer/Makefile
+++ b/icq-relayer/Makefile
@@ -2,7 +2,7 @@
 
 QSVERSION ?= $(shell grep github.com/quicksilver-zone/quicksilver go.mod | grep -Eo 'v[0-9]\.[0-9]\.[0-9].*')
 COMMIT ?= $(shell git log -1 --format='%H')
-VERSION ?= $(shell git describe --tags | grep 'icq-relayer' | head -n1 | sed 's/.*\///')
+VERSION ?= $(shell git describe --tags --match 'icq-relayer/*' | head -n1 | sed 's/.*\///')
 
 ldflags = -X github.com/quicksilver-zone/quicksilver/icq-relayer/pkg/runner.VERSION=icq-relayer/$(VERSION) \
           -X github.com/quicksilver-zone/quicksilver/icq-relayer/pkg/runner.COMMIT=$(COMMIT) \


### PR DESCRIPTION
## 1. Summary
Fixes version tag when releasing both icq-relayer and quicksilver at the same commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced versioning process by filtering tags for improved accuracy in build version identification.
  
- **Bug Fixes**
	- Enforced a specific Go version requirement, ensuring compatibility and reducing potential build issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->