### PR TITLE
fix: ensure we dont attempt to send funds from deposit to delegate after we refund user

### DIFF
--- a/x/interchainstaking/keeper/receipt.go
+++ b/x/interchainstaking/keeper/receipt.go
@@ -122,21 +122,25 @@ func (k *Keeper) HandleReceiptTransaction(ctx sdk.Context, txn *tx.Tx, hash stri
 		k.Logger(ctx).Error("unable to update intent. Ignoring.", "senderAddress", senderAddress, "zone", zone.ChainId, "err", err.Error())
 		return fmt.Errorf("unable to update intent. Ignoring. senderAddress=%q zone=%q err: %w", senderAddress, zone.ChainId, err)
 	}
-	if err := k.MintAndSendQAsset(ctx, senderAccAddress, senderAddress, &zone, assets, memoRTS, mappedAddress); err != nil {
+
+	success, err := k.MintAndSendQAsset(ctx, senderAccAddress, senderAddress, &zone, assets, memoRTS, mappedAddress)
+	if err != nil {
 		k.Logger(ctx).Error("unable to mint QAsset. Ignoring.", "senderAddress", senderAddress, "zone", zone.ChainId, "err", err)
 		return fmt.Errorf("unable to mint QAsset. Ignoring. senderAddress=%q zone=%q err: %w", senderAddress, zone.ChainId, err)
 	}
-	if err := k.TransferToDelegate(ctx, &zone, assets, hash); err != nil {
-		k.Logger(ctx).Error("unable to transfer to delegate. Ignoring.", "senderAddress", senderAddress, "zone", zone.ChainId, "err", err)
-		return fmt.Errorf("unable to transfer to delegate. Ignoring. senderAddress=%q zone=%q err: %w", senderAddress, zone.ChainId, err)
-	}
-	if memoAutoClaim {
-		if err := k.HandleAutoClaim(ctx, senderAccAddress); err != nil {
-			k.Logger(ctx).Error("unable to handle auto claim. Ignoring.", "senderAddress", senderAddress, "zone", zone.ChainId, "err", err)
-			return fmt.Errorf("unable to handle auto claim. Ignoring. senderAddress=%q zone=%q err: %w", senderAddress, zone.ChainId, err)
+
+	if success {
+		if err := k.TransferToDelegate(ctx, &zone, assets, hash); err != nil {
+			k.Logger(ctx).Error("unable to transfer to delegate. Ignoring.", "senderAddress", senderAddress, "zone", zone.ChainId, "err", err)
+			return fmt.Errorf("unable to transfer to delegate. Ignoring. senderAddress=%q zone=%q err: %w", senderAddress, zone.ChainId, err)
+		}
+		if memoAutoClaim {
+			if err := k.HandleAutoClaim(ctx, senderAccAddress); err != nil {
+				k.Logger(ctx).Error("unable to handle auto claim. Ignoring.", "senderAddress", senderAddress, "zone", zone.ChainId, "err", err)
+				return fmt.Errorf("unable to handle auto claim. Ignoring. senderAddress=%q zone=%q err: %w", senderAddress, zone.ChainId, err)
+			}
 		}
 	}
-
 	// create receipt
 	receipt := k.NewReceipt(ctx, &zone, senderAddress, hash, assets)
 	k.SetReceipt(ctx, *receipt)
@@ -206,9 +210,9 @@ func (k *Keeper) HandleAutoClaim(ctx sdk.Context, senderAddress sdk.AccAddress) 
 //     - Mint QAssets, set new mapping for the mapped account in the keeper, and send to corresponding mapped account.
 //  5. If the zone is 118 and no other flags are set:
 //     - Mint QAssets and transfer to send to msg creator.
-func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, senderAddress string, zone *types.Zone, assets sdk.Coins, memoRTS bool, mappedAddress sdk.AccAddress) error {
+func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, senderAddress string, zone *types.Zone, assets sdk.Coins, memoRTS bool, mappedAddress sdk.AccAddress) (bool, error) {
 	if zone.RedemptionRate.IsZero() {
-		return errors.New("zero redemption rate")
+		return false, errors.New("zero redemption rate")
 	}
 
 	qAssets := sdk.Coins{}
@@ -225,7 +229,7 @@ func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, sende
 		if !found {
 			// if not found, skip minting and refund assets
 			msg := &banktypes.MsgSend{FromAddress: zone.DepositAddress.GetAddress(), ToAddress: senderAddress, Amount: assets}
-			return k.SubmitTx(ctx, []sdk.Msg{msg}, zone.DepositAddress, "refund", zone.MessagesPerTx)
+			return false, k.SubmitTx(ctx, []sdk.Msg{msg}, zone.DepositAddress, "refund", zone.MessagesPerTx)
 		}
 		// do not set, since mapped address already exists
 		setMappedAddress = false
@@ -234,7 +238,7 @@ func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, sende
 	k.Logger(ctx).Info("Minting qAssets for receipt", "assets", qAssets)
 	err := k.BankKeeper.MintCoins(ctx, types.ModuleName, qAssets)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	switch {
@@ -258,7 +262,7 @@ func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, sende
 	}
 
 	if err != nil {
-		return fmt.Errorf("unable to transfer coins: %w", err)
+		return false, fmt.Errorf("unable to transfer coins: %w", err)
 	}
 
 	ctx.EventManager().EmitEvent(
@@ -267,7 +271,7 @@ func (k *Keeper) MintAndSendQAsset(ctx sdk.Context, sender sdk.AccAddress, sende
 			sdk.NewAttribute(sdk.AttributeKeyAmount, qAssets.String()),
 		),
 	)
-	return nil
+	return true, nil
 }
 
 // TransferToDelegate transfers tokens from the zone deposit account address to the zone delegate account address.

--- a/x/interchainstaking/keeper/receipt_test.go
+++ b/x/interchainstaking/keeper/receipt_test.go
@@ -397,8 +397,9 @@ func (suite *KeeperTestSuite) TestMintAndSendQAsset1RR() {
 	amount := sdk.NewCoins(sdk.NewCoin(zone.BaseDenom, sdk.NewInt(5000)))
 
 	// Test sending QAsset
-	err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
+	success, err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
 	suite.NoError(err)
+	suite.True(success)
 
 	// Verify balance of receiver
 	receiverBalance := quicksilver.BankKeeper.GetBalance(ctx, sender, zone.LocalDenom)
@@ -422,8 +423,9 @@ func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RR() {
 	amount := sdk.NewCoins(sdk.NewCoin(zone.BaseDenom, sdk.NewInt(5000)))
 
 	// Test sending QAsset
-	err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
+	success, err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
 	suite.NoError(err)
+	suite.True(success)
 
 	// Verify balance of receiver
 	receiverBalance := quicksilver.BankKeeper.GetBalance(ctx, sender, zone.LocalDenom)
@@ -447,8 +449,9 @@ func (suite *KeeperTestSuite) TestMintAndSendQAssetSub1RR() {
 	amount := sdk.NewCoins(sdk.NewCoin(zone.BaseDenom, sdk.NewInt(5000)))
 
 	// Test sending QAsset
-	err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
+	success, err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
 	suite.NoError(err)
+	suite.True(success)
 
 	// Verify balance of receiver
 	receiverBalance := quicksilver.BankKeeper.GetBalance(ctx, sender, zone.LocalDenom)
@@ -464,6 +467,7 @@ func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RRMappedAccount() {
 
 	zone, found := quicksilver.InterchainstakingKeeper.GetZone(ctx, suite.chainB.ChainID)
 	zone.RedemptionRate = sdk.NewDecWithPrec(110, 2)
+	zone.Is_118 = false
 	suite.True(found)
 
 	senderAddress := addressutils.GenerateAddressForTestWithPrefix("cosmos")
@@ -473,8 +477,9 @@ func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RRMappedAccount() {
 	amount := sdk.NewCoins(sdk.NewCoin(zone.BaseDenom, sdk.NewInt(5000)))
 
 	// Test sending QAsset
-	err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, mappedAccount)
+	success, err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, mappedAccount)
 	suite.NoError(err)
+	suite.True(success)
 
 	// Verify balance of receiver
 	receiverBalance := quicksilver.BankKeeper.GetBalance(ctx, sender, zone.LocalDenom)
@@ -490,6 +495,29 @@ func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RRMappedAccount() {
 	localAddress, found := quicksilver.InterchainstakingKeeper.GetLocalAddressMap(ctx, sender, suite.chainB.ChainID)
 	suite.True(found)
 	suite.Equal(mappedAccount, localAddress)
+}
+
+func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RRNon118NoMappedAccount() {
+	suite.SetupTest()
+	suite.setupTestZones()
+
+	quicksilver := suite.GetQuicksilverApp(suite.chainA)
+	ctx := suite.chainA.GetContext()
+
+	zone, found := quicksilver.InterchainstakingKeeper.GetZone(ctx, suite.chainB.ChainID)
+	zone.RedemptionRate = sdk.NewDecWithPrec(110, 2)
+	zone.Is_118 = false
+	suite.True(found)
+
+	senderAddress := addressutils.GenerateAddressForTestWithPrefix("cosmos")
+	sender := addressutils.MustAccAddressFromBech32(senderAddress, "")
+
+	amount := sdk.NewCoins(sdk.NewCoin(zone.BaseDenom, sdk.NewInt(5000)))
+
+	// Test sending QAsset
+	success, err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, false, nil)
+	suite.NoError(err)
+	suite.False(success)
 }
 
 func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RTS() {
@@ -514,8 +542,9 @@ func (suite *KeeperTestSuite) TestMintAndSendQAssetNon1RTS() {
 	amount := sdk.NewCoins(sdk.NewCoin(zone.BaseDenom, sdk.NewInt(5000)))
 
 	// Test sending QAsset
-	err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, true, nil)
+	success, err := quicksilver.InterchainstakingKeeper.MintAndSendQAsset(ctx, sender, senderAddress, &zone, amount, true, nil)
 	suite.NoError(err)
+	suite.True(success)
 
 	// Verify balance of receiver
 	receiverBalance := quicksilver.BankKeeper.GetBalance(ctx, sender, zone.LocalDenom)


### PR DESCRIPTION
## 1. Summary
Fixes #1761

When we refund the user, ensure we don't attempt to also send a MsgSend to tranfer the same funds to the delegate account.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
