### PR TITLE
add upgrade handler for v1.7.5

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -52,6 +52,7 @@ const (
 	V010700UpgradeName = "v1.7.0"
 	V010702UpgradeName = "v1.7.2"
 	V010704UpgradeName = "v1.7.4"
+	V010705UpgradeName = "v1.7.5"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -27,6 +27,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010700UpgradeName, CreateUpgradeHandler: V010700UpgradeHandler},
 		{UpgradeName: V010702UpgradeName, CreateUpgradeHandler: V010702UpgradeHandler},
 		{UpgradeName: V010704UpgradeName, CreateUpgradeHandler: V010704UpgradeHandler},
+		{UpgradeName: V010705UpgradeName, CreateUpgradeHandler: V010705UpgradeHandler},
 	}
 }
 

--- a/app/upgrades/v1_7.go
+++ b/app/upgrades/v1_7.go
@@ -138,3 +138,24 @@ func V010704UpgradeHandler(
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
 }
+
+func V010705UpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	appKeepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		if isMainnet(ctx) || isTest(ctx) {
+			// get zone
+			zone, found := appKeepers.InterchainstakingKeeper.GetZone(ctx, "cosmoshub-4")
+			if !found {
+				panic("zone not found")
+			}
+
+			appKeepers.InterchainstakingKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
+			zone.LastRedemptionRate = sdk.NewDecWithPrec(138, 2) // correct as of 3/12
+			appKeepers.InterchainstakingKeeper.SetZone(ctx, &zone)
+		}
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}


### PR DESCRIPTION
## 1. Summary
Add upgrade handler and test for v1.7.5.

This upgrade handler resets the redemption rate on Cosmoshub-4, based upon the fixed logic in v1.7.5.

As of 3/12, this would be 1.3875 atom to 1 qatom.

It also sets the last redemption rate to 1.38, which is that rate at which unbondings take place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new upgrade version identifier, `v1.7.5`, to enhance upgrade tracking.
	- Added a new upgrade handler for `v1.7.5` to manage withdrawal records and redemption rates.

- **Bug Fixes**
	- Enhanced logic for handling duplicate withdrawal records and improved error handling.

- **Tests**
	- Added a new test function to validate the functionality of the `v1.7.5` upgrade handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->