### PR TITLE
determinsitic config filtering

### DIFF
--- a/icq-relayer/cmd/run.go
+++ b/icq-relayer/cmd/run.go
@@ -93,6 +93,7 @@ func StartCommand() *cobra.Command {
 			}
 
 			config := InitConfig(homepath)
+			config.FilterHA()
 
 			rpcClient, err := rpchttp.New(config.DefaultChain.RpcUrl, "/websocket")
 			if err != nil {

--- a/icq-relayer/pkg/types/config.go
+++ b/icq-relayer/pkg/types/config.go
@@ -91,12 +91,13 @@ func NewConfig() Config {
 			"celestia":       DefaultReadOnlyChainConfig("celestia", "https://celestia.rpc.quicksilver.zone:443"),
 			"archway-1":      DefaultReadOnlyChainConfig("archway-1", "https://archway-1.rpc.quicksilver.zone:443"),
 			"injective-1":    DefaultReadOnlyChainConfig("injective-1", "https://injective-1.rpc.quicksilver.zone:443"),
-			"centauri-1":     DefaultReadOnlyChainConfig("centauri-1", "https://kujira-1.rpc.quicksilver.zone:443"),
+			"centauri-1":     DefaultReadOnlyChainConfig("centauri-1", "https://centauri-1.rpc.quicksilver.zone:443"),
 			"phoenix-1":      DefaultReadOnlyChainConfig("phoenix-1", "https://phoenix-1.rpc.quicksilver.zone:443"),
 			"omniflixhub-1":  DefaultReadOnlyChainConfig("omniflixhub-1", "https://omniflixhub-1.rpc.quicksilver.zone:443"),
 		},
 		HA: HAConfig{
 			NodeIndex:  0,
+			NodeCount:  1,
 			Redundancy: 1,
 		},
 	}

--- a/icq-relayer/pkg/types/config.go
+++ b/icq-relayer/pkg/types/config.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"log"
 	"maps"
 	"math/rand"
@@ -165,7 +164,6 @@ func DistributeConfigs(N, R, seed int, configs []string) map[int][]string {
 
 	r := rand.New(rand.NewSource(int64(seed)))
 	r.Shuffle(len(configPool), func(i, j int) { configPool[i], configPool[j] = configPool[j], configPool[i] })
-	fmt.Println("Shuffled", configPool)
 	for i, config := range configPool {
 		node := i % N // Ensures an even spread
 		nodeConfigs[node] = append(nodeConfigs[node], config)

--- a/icq-relayer/pkg/types/config.go
+++ b/icq-relayer/pkg/types/config.go
@@ -1,9 +1,14 @@
 package types
 
 import (
+	"fmt"
 	"log"
+	"maps"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -17,11 +22,18 @@ type Config struct {
 	MaxMsgsPerTx   int
 	AllowedQueries []string
 	SkipEpoch      bool
+	HA             HAConfig
 	DefaultChain   *ChainConfig
 	Chains         map[string]*ReadOnlyChainConfig
 	ProtoCodec     *codec.ProtoCodec `toml:"-"`
 	ClientContext  *client.Context   `toml:"-"`
 	HomePath       string            `toml:"-"`
+}
+
+type HAConfig struct {
+	NodeCount  int
+	NodeIndex  int
+	Redundancy int
 }
 
 var (
@@ -78,9 +90,16 @@ func NewConfig() Config {
 			"agoric-3":       DefaultReadOnlyChainConfig("agoric-3", "https://agoric-3.rpc.quicksilver.zone:443"),
 			"secret-4":       DefaultReadOnlyChainConfig("secret-4", "https://secret-4.rpc.quicksilver.zone:443"),
 			"celestia":       DefaultReadOnlyChainConfig("celestia", "https://celestia.rpc.quicksilver.zone:443"),
+			"archway-1":      DefaultReadOnlyChainConfig("archway-1", "https://archway-1.rpc.quicksilver.zone:443"),
+			"injective-1":    DefaultReadOnlyChainConfig("injective-1", "https://injective-1.rpc.quicksilver.zone:443"),
+			"centauri-1":     DefaultReadOnlyChainConfig("centauri-1", "https://kujira-1.rpc.quicksilver.zone:443"),
+			"phoenix-1":      DefaultReadOnlyChainConfig("phoenix-1", "https://phoenix-1.rpc.quicksilver.zone:443"),
+			"omniflixhub-1":  DefaultReadOnlyChainConfig("omniflixhub-1", "https://omniflixhub-1.rpc.quicksilver.zone:443"),
 		},
-		ProtoCodec:    nil,
-		ClientContext: &client.Context{},
+		HA: HAConfig{
+			NodeIndex:  0,
+			Redundancy: 1,
+		},
 	}
 }
 
@@ -93,4 +112,84 @@ func DefaultReadOnlyChainConfig(chainID string, rpcUrl string) *ReadOnlyChainCon
 		QueryRetries:                5,
 		QueryRetryDelayMilliseconds: 400,
 	}
+}
+
+func (c *Config) FilterHA() {
+	seed := 0
+
+	var result map[int][]string
+	chains := slices.Collect(maps.Keys(c.Chains))
+	sort.Strings(chains)
+	for true {
+		seed += 1
+		result = DistributeConfigs(c.HA.NodeCount, c.HA.Redundancy, seed, chains)
+		if CheckDistributions(result) {
+			break
+		}
+	}
+
+	filterMap(c.Chains, result[c.HA.NodeIndex])
+}
+
+func filterMap[V any, K comparable](A map[K]*V, B []K) {
+	// Step 1: Convert slice B into a set for fast lookup
+	keySet := make(map[K]bool)
+	for _, key := range B {
+		keySet[key] = true
+	}
+	for key := range A {
+		if _, exists := keySet[key]; !exists {
+			delete(A, key)
+		}
+	}
+}
+
+func DistributeConfigs(N, R, seed int, configs []string) map[int][]string {
+	if N == 0 {
+		N = 1
+	}
+	if R == 0 {
+		R = 1
+	}
+	nodeConfigs := make(map[int][]string)
+
+	// Step 1: Create a list with `redundancy` copies of each config
+	configPool := make([]string, 0, len(configs)*R)
+	for i := 0; i < len(configs); i++ {
+		for j := 0; j < R; j++ {
+			configPool = append(configPool, configs[i])
+		}
+	}
+
+	// Step 2: Shuffle the config pool with a fixed seed for deterministic results
+
+	r := rand.New(rand.NewSource(int64(seed)))
+	r.Shuffle(len(configPool), func(i, j int) { configPool[i], configPool[j] = configPool[j], configPool[i] })
+	fmt.Println("Shuffled", configPool)
+	for i, config := range configPool {
+		node := i % N // Ensures an even spread
+		nodeConfigs[node] = append(nodeConfigs[node], config)
+	}
+
+	return nodeConfigs
+}
+
+func CheckDistributions(dist map[int][]string) bool {
+	for i := range maps.Values(dist) {
+		if !IsUniqueSliceElements(i) {
+			return false
+		}
+	}
+	return true
+}
+
+func IsUniqueSliceElements[T comparable](inputSlice []T) bool {
+	seen := make(map[T]bool, len(inputSlice))
+	for _, element := range inputSlice {
+		if seen[element] {
+			return false
+		}
+		seen[element] = true
+	}
+	return true
 }

--- a/icq-relayer/test/main.go
+++ b/icq-relayer/test/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"maps"
+	"math/rand"
+)
+
+// DistributeConfigs ensures an even spread of configurations across nodes
+func DistributeConfigs(N, M, redundancy, seed int) map[int][]int {
+	nodeConfigs := make(map[int][]int)
+
+	// Step 1: Create a list with `redundancy` copies of each config
+	configPool := make([]int, 0, N*redundancy)
+	for i := 0; i < N; i++ {
+		for j := 0; j < redundancy; j++ {
+			configPool = append(configPool, i)
+		}
+	}
+
+	// Step 2: Shuffle the config pool with a fixed seed for deterministic results
+	rand.Seed(int64(seed))
+	rand.Shuffle(len(configPool), func(i, j int) { configPool[i], configPool[j] = configPool[j], configPool[i] })
+
+	// Step 3: Assign configurations to nodes in a round-robin fashion
+	for i, config := range configPool {
+		node := i % M // Ensures an even spread
+		nodeConfigs[node] = append(nodeConfigs[node], config)
+	}
+
+	return nodeConfigs
+}
+
+func CheckDistributions(dist map[int][]int) bool {
+	for i := range maps.Values(dist) {
+		if !IsUniqueSliceElements(i) { return false; }
+	}
+	return true
+}
+
+func IsUniqueSliceElements[T comparable](inputSlice []T) bool {
+	seen := make(map[T]bool, len(inputSlice))
+	for _, element := range inputSlice {
+		if seen[element] {
+			return false
+		}
+		seen[element] = true
+	}
+	return true
+}
+
+func main() {
+	N := 10  // Number of configurations
+	M := 4   // Number of nodes
+	redundancy := 3 // Each config appears exactly `redundancy` times
+	seed := 0 // Deterministic seed for reproducibility
+
+	var result map[int][]int
+	for true {
+		seed = seed + 1
+		result = DistributeConfigs(N, M, redundancy, seed)
+		check := CheckDistributions(result)
+		if check { break }
+	}
+
+	fmt.Printf("Took %d iterations\n\n", seed) 
+	for node, configs := range result {
+		fmt.Printf("Node %d will have configs: %v (Total: %d)\n", node, configs, len(configs))
+	}
+}
+


### PR DESCRIPTION
## 1. Summary

With a larger number of chains, the order of the config has an impact on how well icq services chains.

This PR adds deterministic config filtering, such that we can config each instance of ICQ with the same set of configs, and a HA stanza (number of nodes, node index, and redundancy) such that the binary can self allocate, in a deterministic fashion, configs such that each node serves a non-identical subset of chains, ensuring redundancy and randomisation of config.

This PR adds a new config element:
```
[HA]
  NodeIndex = 0
  NodeCount = 1
  Redundancy = 1
```

Default values allow ICQ to retain previous behaviour. 

To split chain configs across 4 nodes, with each config covered by exactly 2 instances, use the following:
```
[HA]
  NodeIndex = n
  NodeCount = 4
  Redundancy = 2
```

where `n` is the index of that node between `0..nodeCount-1`. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced relayer configuration with high availability support, enabling a more robust and balanced distribution of settings across nodes.
  - Improved startup processing to incorporate dynamic configuration filtering for reliable server initialization.

- **Tests**
  - Added a validation program to ensure configurations are evenly distributed and unique across nodes.
  - Introduced functions for configuration distribution and uniqueness verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->