### PR TITLE
add no-op handler for v1.8.0-rc.1

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -24,7 +24,8 @@ const (
 	V010706UpgradeName = "v1.7.6"
 	V010707UpgradeName = "v1.7.7"
 
-	V010800UpgradeName = "v1.8.0"
+	V010800UpgradeName   = "v1.8.0"
+	V010800r1UpgradeName = "v1.8.0-rc.1"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -17,6 +17,8 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010706UpgradeName, CreateUpgradeHandler: V010706UpgradeHandler},
 		{UpgradeName: V010707UpgradeName, CreateUpgradeHandler: NoOpHandler},
 
+		{UpgradeName: V010800r1UpgradeName, CreateUpgradeHandler: NoOpHandler},
+
 		{UpgradeName: V010800UpgradeName, CreateUpgradeHandler: V010800UpgradeHandler},
 	}
 }


### PR DESCRIPTION
## 1. Summary
Add no-op upgrade handler for v1.8.0-rc.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new pre-release upgrade option labeled "v1.8.0-rc.1," expanding the versioning scheme.
  - Integrated the new upgrade smoothly with the existing upgrade process for improved release flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->