### PR TITLE
guard against panic in spot price

### DIFF
--- a/third-party-chains/osmosis-types/concentrated-liquidity/model/pool.go
+++ b/third-party-chains/osmosis-types/concentrated-liquidity/model/pool.go
@@ -125,6 +125,9 @@ func (p Pool) SpotPrice(ctx sdk.Context, quoteAssetDenom string, baseAssetDenom 
 	if baseAssetDenom == p.Token0 {
 		return osmomath.BigDecFromDecMut(priceSquared.Dec()), nil
 	}
+	if priceSquared.IsZero() {
+		return osmomath.BigDec{}, fmt.Errorf("price squared is zero")
+	}
 	return osmomath.BigDecFromDecMut(osmomath.OneBigDec().QuoMut(priceSquared).Dec()), nil
 }
 


### PR DESCRIPTION
## 1. Summary
Fixes #1910 

Avoids panic in endblocker by checking for div by zero.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in price calculations to prevent invalid or zero price results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->